### PR TITLE
Replace exception-causing casts from infinite service to an arrival curve

### DIFF
--- a/src/main/java/de/uni_kl/cs/discodnc/algebra/disco/affine/Convolution_Disco_Affine.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/algebra/disco/affine/Convolution_Disco_Affine.java
@@ -182,7 +182,7 @@ public abstract class Convolution_Disco_Affine {
             return arrival_curves.iterator().next().copy();
         }
 
-        ArrivalCurve arrival_curve_result = (ArrivalCurve) Curve.getFactory().createZeroDelayInfiniteBurst();
+        ArrivalCurve arrival_curve_result = Curve.getFactory().createInfiniteArrivals();
         for (ArrivalCurve arrival_curve_2 : arrival_curves) {
             arrival_curve_result = convolve(arrival_curve_result, arrival_curve_2);
         }

--- a/src/main/java/de/uni_kl/cs/discodnc/algebra/disco/affine/Deconvolution_Disco_Affine.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/algebra/disco/affine/Deconvolution_Disco_Affine.java
@@ -51,7 +51,7 @@ public abstract class Deconvolution_Disco_Affine {
                 results.add(Curve.getFactory().createZeroArrivals());
                 return results;
             case 2:
-                results.add((ArrivalCurve) Curve.getFactory().createZeroDelayInfiniteBurst());
+                results.add(Curve.getFactory().createInfiniteArrivals());
                 return results;
             default:
         }
@@ -78,7 +78,7 @@ public abstract class Deconvolution_Disco_Affine {
                 results.add(Curve.getFactory().createZeroArrivals());
                 return results;
             case 2:
-                results.add((ArrivalCurve) Curve.getFactory().createZeroDelayInfiniteBurst());
+                results.add(Curve.getFactory().createInfiniteArrivals());
                 return results;
             default:
         }
@@ -90,7 +90,7 @@ public abstract class Deconvolution_Disco_Affine {
                 results.add(Curve.getFactory().createZeroArrivals());
                 return results;
             case 2:
-                results.add((ArrivalCurve) Curve.getFactory().createZeroDelayInfiniteBurst());
+                results.add(Curve.getFactory().createInfiniteArrivals());
                 return results;
             default:
         }
@@ -112,7 +112,7 @@ public abstract class Deconvolution_Disco_Affine {
             case 3:
                 return Curve.getFactory().createZeroArrivals();
             case 2:
-                return (ArrivalCurve) Curve.getFactory().createZeroDelayInfiniteBurst();
+                return Curve.getFactory().createInfiniteArrivals();
             default:
         }
 
@@ -142,7 +142,7 @@ public abstract class Deconvolution_Disco_Affine {
                 results.add(Curve.getFactory().createZeroArrivals());
                 return results;
             case 2:
-                results.add((ArrivalCurve) Curve.getFactory().createZeroDelayInfiniteBurst());
+                results.add(Curve.getFactory().createInfiniteArrivals());
                 return results;
             default:
         }
@@ -154,7 +154,7 @@ public abstract class Deconvolution_Disco_Affine {
                 results.add(Curve.getFactory().createZeroArrivals());
                 return results;
             case 2:
-                results.add((ArrivalCurve) Curve.getFactory().createZeroDelayInfiniteBurst());
+                results.add(Curve.getFactory().createInfiniteArrivals());
                 return results;
             default:
         }
@@ -181,7 +181,7 @@ public abstract class Deconvolution_Disco_Affine {
             case 3:
                 return Curve.getFactory().createZeroArrivals();
             case 2:
-                return (ArrivalCurve) Curve.getFactory().createZeroDelayInfiniteBurst();
+                return Curve.getFactory().createInfiniteArrivals();
             default:
         }
 

--- a/src/main/java/de/uni_kl/cs/discodnc/algebra/disco/pwaffine/Convolution_Disco_PwAffine.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/algebra/disco/pwaffine/Convolution_Disco_PwAffine.java
@@ -258,7 +258,7 @@ public abstract class Convolution_Disco_PwAffine {
             return arrival_curves.iterator().next().copy();
         }
 
-        ArrivalCurve arrival_curve_result = (ArrivalCurve) Curve.getFactory().createZeroDelayInfiniteBurst();
+        ArrivalCurve arrival_curve_result = Curve.getFactory().createInfiniteArrivals();
         for (ArrivalCurve arrival_curve_2 : arrival_curves) {
             arrival_curve_result = convolve(arrival_curve_result, arrival_curve_2);
         }

--- a/src/main/java/de/uni_kl/cs/discodnc/algebra/disco/pwaffine/Deconvolution_Disco_PwAffine.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/algebra/disco/pwaffine/Deconvolution_Disco_PwAffine.java
@@ -55,7 +55,7 @@ public abstract class Deconvolution_Disco_PwAffine {
                 results.add(Curve.getFactory().createZeroArrivals());
                 return results;
             case 2:
-                results.add((ArrivalCurve) Curve.getFactory().createZeroDelayInfiniteBurst());
+                results.add(Curve.getFactory().createInfiniteArrivals());
                 return results;
             default:
         }
@@ -82,7 +82,7 @@ public abstract class Deconvolution_Disco_PwAffine {
                 results.add(Curve.getFactory().createZeroArrivals());
                 return results;
             case 2:
-                results.add((ArrivalCurve) Curve.getFactory().createZeroDelayInfiniteBurst());
+                results.add(Curve.getFactory().createInfiniteArrivals());
                 return results;
             default:
         }
@@ -94,7 +94,7 @@ public abstract class Deconvolution_Disco_PwAffine {
                 results.add(Curve.getFactory().createZeroArrivals());
                 return results;
             case 2:
-                results.add((ArrivalCurve) Curve.getFactory().createZeroDelayInfiniteBurst());
+                results.add(Curve.getFactory().createInfiniteArrivals());
                 return results;
             default:
         }
@@ -116,7 +116,7 @@ public abstract class Deconvolution_Disco_PwAffine {
             case 3:
                 return Curve.getFactory().createZeroArrivals();
             case 2:
-                return (ArrivalCurve) Curve.getFactory().createZeroDelayInfiniteBurst();
+                return Curve.getFactory().createInfiniteArrivals();
             default:
         }
 
@@ -146,7 +146,7 @@ public abstract class Deconvolution_Disco_PwAffine {
                 results.add(Curve.getFactory().createZeroArrivals());
                 return results;
             case 2:
-                results.add((ArrivalCurve) Curve.getFactory().createZeroDelayInfiniteBurst());
+                results.add(Curve.getFactory().createInfiniteArrivals());
                 return results;
             default:
         }
@@ -158,7 +158,7 @@ public abstract class Deconvolution_Disco_PwAffine {
                 results.add(Curve.getFactory().createZeroArrivals());
                 return results;
             case 2:
-                results.add((ArrivalCurve) Curve.getFactory().createZeroDelayInfiniteBurst());
+                results.add(Curve.getFactory().createInfiniteArrivals());
                 return results;
             default:
         }
@@ -193,7 +193,7 @@ public abstract class Deconvolution_Disco_PwAffine {
             case 3:
                 return Curve.getFactory().createZeroArrivals();
             case 2:
-                return (ArrivalCurve) Curve.getFactory().createZeroDelayInfiniteBurst();
+                return Curve.getFactory().createInfiniteArrivals();
             default:
         }
         // }


### PR DESCRIPTION
In the rare cases these code paths are called, the DiscoDNC would have failed with a "cannot cast" exception.