### PR TITLE
Remove createInfiniteMaxService

### DIFF
--- a/src/main/java/de/uni_kl/cs/discodnc/curves/Curve.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/curves/Curve.java
@@ -751,8 +751,6 @@ public interface Curve {
 
     MaxServiceCurve createMaxServiceCurve(Curve curve);
 
-    MaxServiceCurve createInfiniteMaxService();
-
     MaxServiceCurve createZeroDelayInfiniteBurstMSC();
 
     MaxServiceCurve createDelayedInfiniteBurstMSC(double delay);

--- a/src/main/java/de/uni_kl/cs/discodnc/curves/disco/pwaffine/Curve_Disco_PwAffine.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/curves/disco/pwaffine/Curve_Disco_PwAffine.java
@@ -1200,10 +1200,6 @@ public class Curve_Disco_PwAffine implements Curve_PwAffine {
 		return new MaxServiceCurve_Disco_PwAffine(curve);
 	}
 
-	public MaxServiceCurve_Disco_PwAffine createInfiniteMaxService() {
-		return createDelayedInfiniteBurstMSC(Num.getFactory(Calculator.getInstance().getNumBackend()).createZero());
-	}
-
 	public MaxServiceCurve_Disco_PwAffine createZeroDelayInfiniteBurstMSC() {
 		return createDelayedInfiniteBurstMSC(Num.getFactory(Calculator.getInstance().getNumBackend()).createZero());
 	}


### PR DESCRIPTION
It is redundant to createDelayedInfiniteBurstMSC and was never called.

Found this while thinking about issue #43.