### PR TITLE
Separation of Tandem, FeedForward and SinkTree packages

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -8,12 +8,12 @@ Refactoring:
   - The package "minplus" was renamed to the more general "algebra" and disco's implementations for affine an piecewise affine curves were split up.
   - The packages of in network were moved to network.server_graph and renamed to clarify that we work wit the turn model, not the big switch model
     - Network was renamed to ServerGraph, NetworkFactory to ServerGraphFactory, Link to Turn.
-  - Package "nc" was renamed to feedforward and class naming was improved to catch up with DNC theory.
+  - Package "nc" was split up and renamed to feedforward, tandem or sinktree. Class naming was improved to catch up with DNC theory.
     - PbooArrivalBound_Concatenation -> AggregatePboo_Concatenation, PbooArrivalBound_PerHop -> AggregatePboo_PerServer
     - PmooArrivalBound -> AggregatePmoo
     - TandemMatchingArrivalBound -> AggregateTandemMatching
     - PmooArrivalBound_SinkTreeTbRl -> SinkTree_AffineCurves
-* Code paths for affine and piecewise affine curves were better separated  
+* Code paths for affine and piecewise affine curves were better separated.
 * Functional tests, experiments and MPA RTC curve backend moved into git submodules.
 
 Other changes and additions:

--- a/src/main/java/de/uni_kl/cs/discodnc/AnalysisConfig.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/AnalysisConfig.java
@@ -26,7 +26,7 @@
  *
  */
 
-package de.uni_kl.cs.discodnc.feedforward;
+package de.uni_kl.cs.discodnc;
 
 import java.util.Collections;
 import java.util.HashSet;

--- a/src/main/java/de/uni_kl/cs/discodnc/CompFFApresets.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/CompFFApresets.java
@@ -1,16 +1,15 @@
-package de.uni_kl.cs.discodnc.feedforward;
+package de.uni_kl.cs.discodnc;
 
 import java.util.HashSet;
 import java.util.Set;
 
-import de.uni_kl.cs.discodnc.Calculator;
-import de.uni_kl.cs.discodnc.feedforward.AnalysisConfig.ArrivalBoundMethod;
-import de.uni_kl.cs.discodnc.feedforward.AnalysisConfig.GammaFlag;
-import de.uni_kl.cs.discodnc.feedforward.AnalysisConfig.MuxDiscipline;
-import de.uni_kl.cs.discodnc.feedforward.analyses.PmooAnalysis;
-import de.uni_kl.cs.discodnc.feedforward.analyses.SeparateFlowAnalysis;
-import de.uni_kl.cs.discodnc.feedforward.analyses.TotalFlowAnalysis;
+import de.uni_kl.cs.discodnc.AnalysisConfig.ArrivalBoundMethod;
+import de.uni_kl.cs.discodnc.AnalysisConfig.GammaFlag;
+import de.uni_kl.cs.discodnc.AnalysisConfig.MuxDiscipline;
 import de.uni_kl.cs.discodnc.network.server_graph.ServerGraph;
+import de.uni_kl.cs.discodnc.tandem.analyses.PmooAnalysis;
+import de.uni_kl.cs.discodnc.tandem.analyses.SeparateFlowAnalysis;
+import de.uni_kl.cs.discodnc.tandem.analyses.TotalFlowAnalysis;
 
 public class CompFFApresets {
 	private ServerGraph network;

--- a/src/main/java/de/uni_kl/cs/discodnc/bounds/disco/pwaffine/Backlog.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/bounds/disco/pwaffine/Backlog.java
@@ -31,17 +31,17 @@ package de.uni_kl.cs.discodnc.bounds.disco.pwaffine;
 
 import java.util.ArrayList;
 
+import de.uni_kl.cs.discodnc.AnalysisConfig;
 import de.uni_kl.cs.discodnc.Calculator;
 import de.uni_kl.cs.discodnc.curves.ArrivalCurve;
 import de.uni_kl.cs.discodnc.curves.Curve;
 import de.uni_kl.cs.discodnc.curves.ServiceCurve;
-import de.uni_kl.cs.discodnc.feedforward.AnalysisConfig;
-import de.uni_kl.cs.discodnc.feedforward.arrivalbounds.SinkTree_AffineCurves;
 import de.uni_kl.cs.discodnc.network.server_graph.Flow;
 import de.uni_kl.cs.discodnc.network.server_graph.Server;
 import de.uni_kl.cs.discodnc.network.server_graph.ServerGraph;
 import de.uni_kl.cs.discodnc.network.server_graph.Turn;
 import de.uni_kl.cs.discodnc.numbers.Num;
+import de.uni_kl.cs.discodnc.sinktree.arrivalbounds.SinkTree_AffineCurves;
 
 public class Backlog {
 	private Backlog() {

--- a/src/main/java/de/uni_kl/cs/discodnc/bounds/disco/pwaffine/Bound.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/bounds/disco/pwaffine/Bound.java
@@ -29,9 +29,9 @@ package de.uni_kl.cs.discodnc.bounds.disco.pwaffine;
 
 import java.util.Set;
 
+import de.uni_kl.cs.discodnc.AnalysisConfig;
 import de.uni_kl.cs.discodnc.curves.ArrivalCurve;
 import de.uni_kl.cs.discodnc.curves.ServiceCurve;
-import de.uni_kl.cs.discodnc.feedforward.AnalysisConfig;
 import de.uni_kl.cs.discodnc.network.server_graph.Path;
 import de.uni_kl.cs.discodnc.network.server_graph.Server;
 import de.uni_kl.cs.discodnc.network.server_graph.ServerGraph;

--- a/src/main/java/de/uni_kl/cs/discodnc/bounds/disco/pwaffine/LeftOverService.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/bounds/disco/pwaffine/LeftOverService.java
@@ -35,13 +35,13 @@ import java.util.Set;
 
 import org.apache.commons.math3.util.Pair;
 
+import de.uni_kl.cs.discodnc.AnalysisConfig;
 import de.uni_kl.cs.discodnc.Calculator;
+import de.uni_kl.cs.discodnc.AnalysisConfig.Multiplexing;
+import de.uni_kl.cs.discodnc.AnalysisConfig.MuxDiscipline;
 import de.uni_kl.cs.discodnc.curves.ArrivalCurve;
 import de.uni_kl.cs.discodnc.curves.Curve;
 import de.uni_kl.cs.discodnc.curves.ServiceCurve;
-import de.uni_kl.cs.discodnc.feedforward.AnalysisConfig;
-import de.uni_kl.cs.discodnc.feedforward.AnalysisConfig.Multiplexing;
-import de.uni_kl.cs.discodnc.feedforward.AnalysisConfig.MuxDiscipline;
 import de.uni_kl.cs.discodnc.network.server_graph.Server;
 import de.uni_kl.cs.discodnc.numbers.Num;
 

--- a/src/main/java/de/uni_kl/cs/discodnc/bounds/disco/pwaffine/Output.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/bounds/disco/pwaffine/Output.java
@@ -32,10 +32,10 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import de.uni_kl.cs.discodnc.AnalysisConfig;
 import de.uni_kl.cs.discodnc.Calculator;
 import de.uni_kl.cs.discodnc.curves.ArrivalCurve;
 import de.uni_kl.cs.discodnc.curves.ServiceCurve;
-import de.uni_kl.cs.discodnc.feedforward.AnalysisConfig;
 import de.uni_kl.cs.discodnc.network.server_graph.Path;
 import de.uni_kl.cs.discodnc.network.server_graph.Server;
 

--- a/src/main/java/de/uni_kl/cs/discodnc/demos/Demo1.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/demos/Demo1.java
@@ -28,17 +28,17 @@
 
 package de.uni_kl.cs.discodnc.demos;
 
+import de.uni_kl.cs.discodnc.AnalysisConfig;
 import de.uni_kl.cs.discodnc.curves.ArrivalCurve;
 import de.uni_kl.cs.discodnc.curves.Curve;
 import de.uni_kl.cs.discodnc.curves.MaxServiceCurve;
 import de.uni_kl.cs.discodnc.curves.ServiceCurve;
-import de.uni_kl.cs.discodnc.feedforward.AnalysisConfig;
-import de.uni_kl.cs.discodnc.feedforward.analyses.PmooAnalysis;
-import de.uni_kl.cs.discodnc.feedforward.analyses.SeparateFlowAnalysis;
-import de.uni_kl.cs.discodnc.feedforward.analyses.TotalFlowAnalysis;
 import de.uni_kl.cs.discodnc.network.server_graph.Flow;
 import de.uni_kl.cs.discodnc.network.server_graph.Server;
 import de.uni_kl.cs.discodnc.network.server_graph.ServerGraph;
+import de.uni_kl.cs.discodnc.tandem.analyses.PmooAnalysis;
+import de.uni_kl.cs.discodnc.tandem.analyses.SeparateFlowAnalysis;
+import de.uni_kl.cs.discodnc.tandem.analyses.TotalFlowAnalysis;
 
 public class Demo1 {
 

--- a/src/main/java/de/uni_kl/cs/discodnc/demos/Demo2.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/demos/Demo2.java
@@ -32,12 +32,12 @@ import de.uni_kl.cs.discodnc.curves.ArrivalCurve;
 import de.uni_kl.cs.discodnc.curves.Curve;
 import de.uni_kl.cs.discodnc.curves.MaxServiceCurve;
 import de.uni_kl.cs.discodnc.curves.ServiceCurve;
-import de.uni_kl.cs.discodnc.feedforward.analyses.PmooAnalysis;
-import de.uni_kl.cs.discodnc.feedforward.analyses.SeparateFlowAnalysis;
-import de.uni_kl.cs.discodnc.feedforward.analyses.TotalFlowAnalysis;
 import de.uni_kl.cs.discodnc.network.server_graph.Flow;
 import de.uni_kl.cs.discodnc.network.server_graph.Server;
 import de.uni_kl.cs.discodnc.network.server_graph.ServerGraph;
+import de.uni_kl.cs.discodnc.tandem.analyses.PmooAnalysis;
+import de.uni_kl.cs.discodnc.tandem.analyses.SeparateFlowAnalysis;
+import de.uni_kl.cs.discodnc.tandem.analyses.TotalFlowAnalysis;
 
 public class Demo2 {
 

--- a/src/main/java/de/uni_kl/cs/discodnc/demos/Demo3.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/demos/Demo3.java
@@ -32,12 +32,12 @@ import de.uni_kl.cs.discodnc.curves.ArrivalCurve;
 import de.uni_kl.cs.discodnc.curves.Curve;
 import de.uni_kl.cs.discodnc.curves.MaxServiceCurve;
 import de.uni_kl.cs.discodnc.curves.ServiceCurve;
-import de.uni_kl.cs.discodnc.feedforward.analyses.PmooAnalysis;
-import de.uni_kl.cs.discodnc.feedforward.analyses.SeparateFlowAnalysis;
-import de.uni_kl.cs.discodnc.feedforward.analyses.TotalFlowAnalysis;
 import de.uni_kl.cs.discodnc.network.server_graph.Flow;
 import de.uni_kl.cs.discodnc.network.server_graph.Server;
 import de.uni_kl.cs.discodnc.network.server_graph.ServerGraph;
+import de.uni_kl.cs.discodnc.tandem.analyses.PmooAnalysis;
+import de.uni_kl.cs.discodnc.tandem.analyses.SeparateFlowAnalysis;
+import de.uni_kl.cs.discodnc.tandem.analyses.TotalFlowAnalysis;
 
 public class Demo3 {
 

--- a/src/main/java/de/uni_kl/cs/discodnc/demos/Demo4.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/demos/Demo4.java
@@ -28,18 +28,18 @@
 
 package de.uni_kl.cs.discodnc.demos;
 
+import de.uni_kl.cs.discodnc.CompFFApresets;
 import de.uni_kl.cs.discodnc.curves.ArrivalCurve;
 import de.uni_kl.cs.discodnc.curves.Curve;
 import de.uni_kl.cs.discodnc.curves.MaxServiceCurve;
 import de.uni_kl.cs.discodnc.curves.ServiceCurve;
-import de.uni_kl.cs.discodnc.feedforward.CompFFApresets;
-import de.uni_kl.cs.discodnc.feedforward.analyses.PmooAnalysis;
-import de.uni_kl.cs.discodnc.feedforward.analyses.SeparateFlowAnalysis;
-import de.uni_kl.cs.discodnc.feedforward.analyses.TotalFlowAnalysis;
 import de.uni_kl.cs.discodnc.network.server_graph.Flow;
 import de.uni_kl.cs.discodnc.network.server_graph.Server;
 import de.uni_kl.cs.discodnc.network.server_graph.ServerGraph;
 import de.uni_kl.cs.discodnc.network.server_graph.Turn;
+import de.uni_kl.cs.discodnc.tandem.analyses.PmooAnalysis;
+import de.uni_kl.cs.discodnc.tandem.analyses.SeparateFlowAnalysis;
+import de.uni_kl.cs.discodnc.tandem.analyses.TotalFlowAnalysis;
 
 import java.util.LinkedList;
 

--- a/src/main/java/de/uni_kl/cs/discodnc/feedforward/AbstractArrivalBound.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/feedforward/AbstractArrivalBound.java
@@ -28,6 +28,7 @@
 
 package de.uni_kl.cs.discodnc.feedforward;
 
+import de.uni_kl.cs.discodnc.AnalysisConfig;
 import de.uni_kl.cs.discodnc.network.server_graph.ServerGraph;
 
 public abstract class AbstractArrivalBound implements ArrivalBound {

--- a/src/main/java/de/uni_kl/cs/discodnc/feedforward/ArrivalBound.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/feedforward/ArrivalBound.java
@@ -30,6 +30,7 @@ package de.uni_kl.cs.discodnc.feedforward;
 
 import java.util.Set;
 
+import de.uni_kl.cs.discodnc.AnalysisConfig;
 import de.uni_kl.cs.discodnc.curves.ArrivalCurve;
 import de.uni_kl.cs.discodnc.network.server_graph.Flow;
 import de.uni_kl.cs.discodnc.network.server_graph.ServerGraph;

--- a/src/main/java/de/uni_kl/cs/discodnc/feedforward/ArrivalBoundDispatch.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/feedforward/ArrivalBoundDispatch.java
@@ -33,13 +33,11 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
+import de.uni_kl.cs.discodnc.AnalysisConfig;
 import de.uni_kl.cs.discodnc.Calculator;
 import de.uni_kl.cs.discodnc.curves.ArrivalCurve;
 import de.uni_kl.cs.discodnc.curves.Curve;
 import de.uni_kl.cs.discodnc.curves.ServiceCurve;
-import de.uni_kl.cs.discodnc.feedforward.analyses.PmooAnalysis;
-import de.uni_kl.cs.discodnc.feedforward.analyses.SeparateFlowAnalysis;
-import de.uni_kl.cs.discodnc.feedforward.analyses.TandemMatchingAnalysis;
 import de.uni_kl.cs.discodnc.feedforward.arrivalbounds.AggregatePboo_Concatenation;
 import de.uni_kl.cs.discodnc.feedforward.arrivalbounds.AggregatePboo_PerServer;
 import de.uni_kl.cs.discodnc.feedforward.arrivalbounds.AggregatePmoo;
@@ -48,6 +46,9 @@ import de.uni_kl.cs.discodnc.network.server_graph.Flow;
 import de.uni_kl.cs.discodnc.network.server_graph.Server;
 import de.uni_kl.cs.discodnc.network.server_graph.ServerGraph;
 import de.uni_kl.cs.discodnc.network.server_graph.Turn;
+import de.uni_kl.cs.discodnc.tandem.analyses.PmooAnalysis;
+import de.uni_kl.cs.discodnc.tandem.analyses.SeparateFlowAnalysis;
+import de.uni_kl.cs.discodnc.tandem.analyses.TandemMatchingAnalysis;
 import de.uni_kl.cs.discodnc.utils.SetUtils;
 
 public abstract class ArrivalBoundDispatch {

--- a/src/main/java/de/uni_kl/cs/discodnc/feedforward/arrivalbounds/AggregatePboo_Concatenation.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/feedforward/arrivalbounds/AggregatePboo_Concatenation.java
@@ -35,20 +35,20 @@ import java.util.Set;
 import de.uni_kl.cs.discodnc.Calculator;
 import de.uni_kl.cs.discodnc.bounds.disco.pwaffine.Bound;
 import de.uni_kl.cs.discodnc.AlgDncBackend_DNC_Affine;
+import de.uni_kl.cs.discodnc.AnalysisConfig;
 import de.uni_kl.cs.discodnc.curves.ArrivalCurve;
 import de.uni_kl.cs.discodnc.curves.Curve;
 import de.uni_kl.cs.discodnc.curves.ServiceCurve;
 import de.uni_kl.cs.discodnc.feedforward.AbstractArrivalBound;
-import de.uni_kl.cs.discodnc.feedforward.AnalysisConfig;
 import de.uni_kl.cs.discodnc.feedforward.ArrivalBound;
 import de.uni_kl.cs.discodnc.feedforward.ArrivalBoundDispatch;
-import de.uni_kl.cs.discodnc.feedforward.analyses.TotalFlowAnalysis;
 import de.uni_kl.cs.discodnc.network.server_graph.Flow;
 import de.uni_kl.cs.discodnc.network.server_graph.Path;
 import de.uni_kl.cs.discodnc.network.server_graph.Server;
 import de.uni_kl.cs.discodnc.network.server_graph.ServerGraph;
 import de.uni_kl.cs.discodnc.network.server_graph.Turn;
 import de.uni_kl.cs.discodnc.numbers.Num;
+import de.uni_kl.cs.discodnc.tandem.analyses.TotalFlowAnalysis;
 import de.uni_kl.cs.discodnc.utils.SetUtils;
 
 public class AggregatePboo_Concatenation extends AbstractArrivalBound implements ArrivalBound {

--- a/src/main/java/de/uni_kl/cs/discodnc/feedforward/arrivalbounds/AggregatePboo_PerServer.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/feedforward/arrivalbounds/AggregatePboo_PerServer.java
@@ -35,20 +35,20 @@ import java.util.Set;
 import de.uni_kl.cs.discodnc.Calculator;
 import de.uni_kl.cs.discodnc.bounds.disco.pwaffine.Bound;
 import de.uni_kl.cs.discodnc.AlgDncBackend_DNC_Affine;
+import de.uni_kl.cs.discodnc.AnalysisConfig;
 import de.uni_kl.cs.discodnc.curves.ArrivalCurve;
 import de.uni_kl.cs.discodnc.curves.Curve;
 import de.uni_kl.cs.discodnc.curves.ServiceCurve;
 import de.uni_kl.cs.discodnc.feedforward.AbstractArrivalBound;
-import de.uni_kl.cs.discodnc.feedforward.AnalysisConfig;
 import de.uni_kl.cs.discodnc.feedforward.ArrivalBound;
 import de.uni_kl.cs.discodnc.feedforward.ArrivalBoundDispatch;
-import de.uni_kl.cs.discodnc.feedforward.analyses.TotalFlowAnalysis;
 import de.uni_kl.cs.discodnc.network.server_graph.Flow;
 import de.uni_kl.cs.discodnc.network.server_graph.Path;
 import de.uni_kl.cs.discodnc.network.server_graph.Server;
 import de.uni_kl.cs.discodnc.network.server_graph.ServerGraph;
 import de.uni_kl.cs.discodnc.network.server_graph.Turn;
 import de.uni_kl.cs.discodnc.numbers.Num;
+import de.uni_kl.cs.discodnc.tandem.analyses.TotalFlowAnalysis;
 import de.uni_kl.cs.discodnc.utils.SetUtils;
 
 public class AggregatePboo_PerServer extends AbstractArrivalBound implements ArrivalBound {

--- a/src/main/java/de/uni_kl/cs/discodnc/feedforward/arrivalbounds/AggregatePmoo.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/feedforward/arrivalbounds/AggregatePmoo.java
@@ -33,22 +33,22 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import de.uni_kl.cs.discodnc.AnalysisConfig;
+import de.uni_kl.cs.discodnc.AnalysisConfig.Multiplexing;
+import de.uni_kl.cs.discodnc.AnalysisConfig.MuxDiscipline;
 import de.uni_kl.cs.discodnc.bounds.disco.pwaffine.Bound;
 import de.uni_kl.cs.discodnc.curves.ArrivalCurve;
 import de.uni_kl.cs.discodnc.curves.Curve;
 import de.uni_kl.cs.discodnc.curves.ServiceCurve;
 import de.uni_kl.cs.discodnc.feedforward.AbstractArrivalBound;
-import de.uni_kl.cs.discodnc.feedforward.AnalysisConfig;
 import de.uni_kl.cs.discodnc.feedforward.ArrivalBound;
 import de.uni_kl.cs.discodnc.feedforward.ArrivalBoundDispatch;
-import de.uni_kl.cs.discodnc.feedforward.AnalysisConfig.Multiplexing;
-import de.uni_kl.cs.discodnc.feedforward.AnalysisConfig.MuxDiscipline;
-import de.uni_kl.cs.discodnc.feedforward.analyses.PmooAnalysis;
 import de.uni_kl.cs.discodnc.network.server_graph.Flow;
 import de.uni_kl.cs.discodnc.network.server_graph.Path;
 import de.uni_kl.cs.discodnc.network.server_graph.Server;
 import de.uni_kl.cs.discodnc.network.server_graph.ServerGraph;
 import de.uni_kl.cs.discodnc.network.server_graph.Turn;
+import de.uni_kl.cs.discodnc.tandem.analyses.PmooAnalysis;
 import de.uni_kl.cs.discodnc.utils.SetUtils;
 
 public class AggregatePmoo extends AbstractArrivalBound implements ArrivalBound {

--- a/src/main/java/de/uni_kl/cs/discodnc/feedforward/arrivalbounds/AggregateTandemMatching.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/feedforward/arrivalbounds/AggregateTandemMatching.java
@@ -33,25 +33,25 @@ import java.util.HashSet;
 import java.util.Set;
 
 import de.uni_kl.cs.discodnc.Calculator;
+import de.uni_kl.cs.discodnc.AnalysisConfig.Multiplexing;
+import de.uni_kl.cs.discodnc.AnalysisConfig.MuxDiscipline;
 import de.uni_kl.cs.discodnc.bounds.disco.pwaffine.Bound;
 import de.uni_kl.cs.discodnc.AlgDncBackend_DNC_Affine;
+import de.uni_kl.cs.discodnc.AnalysisConfig;
 import de.uni_kl.cs.discodnc.curves.ArrivalCurve;
 import de.uni_kl.cs.discodnc.curves.Curve;
 import de.uni_kl.cs.discodnc.curves.ServiceCurve;
 import de.uni_kl.cs.discodnc.feedforward.AbstractArrivalBound;
-import de.uni_kl.cs.discodnc.feedforward.AnalysisConfig;
 import de.uni_kl.cs.discodnc.feedforward.ArrivalBound;
 import de.uni_kl.cs.discodnc.feedforward.ArrivalBoundDispatch;
-import de.uni_kl.cs.discodnc.feedforward.AnalysisConfig.Multiplexing;
-import de.uni_kl.cs.discodnc.feedforward.AnalysisConfig.MuxDiscipline;
-import de.uni_kl.cs.discodnc.feedforward.analyses.TandemMatchingAnalysis;
-import de.uni_kl.cs.discodnc.feedforward.analyses.TotalFlowAnalysis;
 import de.uni_kl.cs.discodnc.network.server_graph.Flow;
 import de.uni_kl.cs.discodnc.network.server_graph.Path;
 import de.uni_kl.cs.discodnc.network.server_graph.Server;
 import de.uni_kl.cs.discodnc.network.server_graph.ServerGraph;
 import de.uni_kl.cs.discodnc.network.server_graph.Turn;
 import de.uni_kl.cs.discodnc.numbers.Num;
+import de.uni_kl.cs.discodnc.tandem.analyses.TandemMatchingAnalysis;
+import de.uni_kl.cs.discodnc.tandem.analyses.TotalFlowAnalysis;
 import de.uni_kl.cs.discodnc.utils.SetUtils;
 
 public class AggregateTandemMatching extends AbstractArrivalBound implements ArrivalBound {

--- a/src/main/java/de/uni_kl/cs/discodnc/network/server_graph/Server.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/network/server_graph/Server.java
@@ -28,10 +28,10 @@
 
 package de.uni_kl.cs.discodnc.network.server_graph;
 
+import de.uni_kl.cs.discodnc.AnalysisConfig.Multiplexing;
 import de.uni_kl.cs.discodnc.curves.Curve;
 import de.uni_kl.cs.discodnc.curves.MaxServiceCurve;
 import de.uni_kl.cs.discodnc.curves.ServiceCurve;
-import de.uni_kl.cs.discodnc.feedforward.AnalysisConfig.Multiplexing;
 
 public class Server {
     private int id;

--- a/src/main/java/de/uni_kl/cs/discodnc/network/server_graph/ServerGraph.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/network/server_graph/ServerGraph.java
@@ -40,11 +40,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import de.uni_kl.cs.discodnc.AnalysisConfig.Multiplexing;
 import de.uni_kl.cs.discodnc.curves.ArrivalCurve;
 import de.uni_kl.cs.discodnc.curves.Curve;
 import de.uni_kl.cs.discodnc.curves.MaxServiceCurve;
 import de.uni_kl.cs.discodnc.curves.ServiceCurve;
-import de.uni_kl.cs.discodnc.feedforward.AnalysisConfig.Multiplexing;
 import de.uni_kl.cs.discodnc.utils.SetUtils;
 
 import org.apache.commons.math3.util.Pair;

--- a/src/main/java/de/uni_kl/cs/discodnc/sinktree/arrivalbounds/SinkTree_AffineCurves.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/sinktree/arrivalbounds/SinkTree_AffineCurves.java
@@ -26,7 +26,7 @@
  *
  */
 
-package de.uni_kl.cs.discodnc.feedforward.arrivalbounds;
+package de.uni_kl.cs.discodnc.sinktree.arrivalbounds;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -43,7 +43,7 @@ import de.uni_kl.cs.discodnc.network.server_graph.ServerGraph;
 import de.uni_kl.cs.discodnc.network.server_graph.Turn;
 import de.uni_kl.cs.discodnc.utils.SetUtils;
 
-public class SinkTree_AffineCurves { //extends AbstractArrivalBound {
+public class SinkTree_AffineCurves {
     private static SinkTree_AffineCurves instance = new SinkTree_AffineCurves();
     protected ServerGraph server_graph;
     private PmooSinkTreeTbRlABCache ab_cache = new PmooSinkTreeTbRlABCache();

--- a/src/main/java/de/uni_kl/cs/discodnc/tandem/AbstractAnalysis.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/tandem/AbstractAnalysis.java
@@ -27,11 +27,12 @@
  *
  */
 
-package de.uni_kl.cs.discodnc.feedforward;
+package de.uni_kl.cs.discodnc.tandem;
 
 import java.util.Map;
 import java.util.Set;
 
+import de.uni_kl.cs.discodnc.AnalysisConfig;
 import de.uni_kl.cs.discodnc.curves.ArrivalCurve;
 import de.uni_kl.cs.discodnc.network.server_graph.Server;
 import de.uni_kl.cs.discodnc.network.server_graph.ServerGraph;

--- a/src/main/java/de/uni_kl/cs/discodnc/tandem/Analysis.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/tandem/Analysis.java
@@ -27,14 +27,15 @@
  *
  */
 
-package de.uni_kl.cs.discodnc.feedforward;
+package de.uni_kl.cs.discodnc.tandem;
 
-import de.uni_kl.cs.discodnc.feedforward.analyses.PmooAnalysis;
-import de.uni_kl.cs.discodnc.feedforward.analyses.SeparateFlowAnalysis;
-import de.uni_kl.cs.discodnc.feedforward.analyses.TotalFlowAnalysis;
+import de.uni_kl.cs.discodnc.AnalysisConfig;
 import de.uni_kl.cs.discodnc.network.server_graph.Flow;
 import de.uni_kl.cs.discodnc.network.server_graph.Path;
 import de.uni_kl.cs.discodnc.network.server_graph.ServerGraph;
+import de.uni_kl.cs.discodnc.tandem.analyses.PmooAnalysis;
+import de.uni_kl.cs.discodnc.tandem.analyses.SeparateFlowAnalysis;
+import de.uni_kl.cs.discodnc.tandem.analyses.TotalFlowAnalysis;
 
 public interface Analysis {
     static TotalFlowAnalysis performTfaEnd2End(ServerGraph network, Flow flow_of_interest) throws Exception {

--- a/src/main/java/de/uni_kl/cs/discodnc/tandem/AnalysisResults.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/tandem/AnalysisResults.java
@@ -27,7 +27,7 @@
  *
  */
 
-package de.uni_kl.cs.discodnc.feedforward;
+package de.uni_kl.cs.discodnc.tandem;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/de/uni_kl/cs/discodnc/tandem/analyses/PmooAnalysis.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/tandem/analyses/PmooAnalysis.java
@@ -28,7 +28,7 @@
  *
  */
 
-package de.uni_kl.cs.discodnc.feedforward.analyses;
+package de.uni_kl.cs.discodnc.tandem.analyses;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -39,23 +39,23 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import de.uni_kl.cs.discodnc.AnalysisConfig;
 import de.uni_kl.cs.discodnc.Calculator;
+import de.uni_kl.cs.discodnc.AnalysisConfig.Multiplexing;
+import de.uni_kl.cs.discodnc.AnalysisConfig.MuxDiscipline;
 import de.uni_kl.cs.discodnc.bounds.disco.pwaffine.Bound;
 import de.uni_kl.cs.discodnc.curves.ArrivalCurve;
 import de.uni_kl.cs.discodnc.curves.Curve;
 import de.uni_kl.cs.discodnc.curves.ServiceCurve;
-import de.uni_kl.cs.discodnc.feedforward.AbstractAnalysis;
-import de.uni_kl.cs.discodnc.feedforward.Analysis;
-import de.uni_kl.cs.discodnc.feedforward.AnalysisConfig;
 import de.uni_kl.cs.discodnc.feedforward.ArrivalBoundDispatch;
-import de.uni_kl.cs.discodnc.feedforward.AnalysisConfig.Multiplexing;
-import de.uni_kl.cs.discodnc.feedforward.AnalysisConfig.MuxDiscipline;
 import de.uni_kl.cs.discodnc.network.server_graph.Flow;
 import de.uni_kl.cs.discodnc.network.server_graph.Path;
 import de.uni_kl.cs.discodnc.network.server_graph.Server;
 import de.uni_kl.cs.discodnc.network.server_graph.ServerGraph;
 import de.uni_kl.cs.discodnc.network.server_graph.Turn;
 import de.uni_kl.cs.discodnc.numbers.Num;
+import de.uni_kl.cs.discodnc.tandem.AbstractAnalysis;
+import de.uni_kl.cs.discodnc.tandem.Analysis;
 
 import org.apache.commons.math3.util.Pair;
 

--- a/src/main/java/de/uni_kl/cs/discodnc/tandem/analyses/PmooResults.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/tandem/analyses/PmooResults.java
@@ -28,16 +28,16 @@
  *
  */
 
-package de.uni_kl.cs.discodnc.feedforward.analyses;
+package de.uni_kl.cs.discodnc.tandem.analyses;
 
 import java.util.Map;
 import java.util.Set;
 
 import de.uni_kl.cs.discodnc.curves.ArrivalCurve;
 import de.uni_kl.cs.discodnc.curves.ServiceCurve;
-import de.uni_kl.cs.discodnc.feedforward.AnalysisResults;
 import de.uni_kl.cs.discodnc.network.server_graph.Server;
 import de.uni_kl.cs.discodnc.numbers.Num;
+import de.uni_kl.cs.discodnc.tandem.AnalysisResults;
 
 public class PmooResults extends AnalysisResults {
     protected Set<ServiceCurve> betas_e2e;

--- a/src/main/java/de/uni_kl/cs/discodnc/tandem/analyses/SeparateFlowAnalysis.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/tandem/analyses/SeparateFlowAnalysis.java
@@ -28,7 +28,7 @@
  *
  */
 
-package de.uni_kl.cs.discodnc.feedforward.analyses;
+package de.uni_kl.cs.discodnc.tandem.analyses;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -38,14 +38,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import de.uni_kl.cs.discodnc.AnalysisConfig;
 import de.uni_kl.cs.discodnc.Calculator;
 import de.uni_kl.cs.discodnc.bounds.disco.pwaffine.Bound;
 import de.uni_kl.cs.discodnc.curves.ArrivalCurve;
 import de.uni_kl.cs.discodnc.curves.Curve;
 import de.uni_kl.cs.discodnc.curves.ServiceCurve;
-import de.uni_kl.cs.discodnc.feedforward.AbstractAnalysis;
-import de.uni_kl.cs.discodnc.feedforward.Analysis;
-import de.uni_kl.cs.discodnc.feedforward.AnalysisConfig;
 import de.uni_kl.cs.discodnc.feedforward.ArrivalBoundDispatch;
 import de.uni_kl.cs.discodnc.network.server_graph.Flow;
 import de.uni_kl.cs.discodnc.network.server_graph.Path;
@@ -53,6 +51,8 @@ import de.uni_kl.cs.discodnc.network.server_graph.Server;
 import de.uni_kl.cs.discodnc.network.server_graph.ServerGraph;
 import de.uni_kl.cs.discodnc.network.server_graph.Turn;
 import de.uni_kl.cs.discodnc.numbers.Num;
+import de.uni_kl.cs.discodnc.tandem.AbstractAnalysis;
+import de.uni_kl.cs.discodnc.tandem.Analysis;
 import de.uni_kl.cs.discodnc.utils.SetUtils;
 
 public class SeparateFlowAnalysis extends AbstractAnalysis implements Analysis {

--- a/src/main/java/de/uni_kl/cs/discodnc/tandem/analyses/SeparateFlowResults.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/tandem/analyses/SeparateFlowResults.java
@@ -28,58 +28,38 @@
  *
  */
 
-package de.uni_kl.cs.discodnc.feedforward.analyses;
+package de.uni_kl.cs.discodnc.tandem.analyses;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
 import de.uni_kl.cs.discodnc.curves.ArrivalCurve;
-import de.uni_kl.cs.discodnc.feedforward.AnalysisResults;
+import de.uni_kl.cs.discodnc.curves.ServiceCurve;
 import de.uni_kl.cs.discodnc.network.server_graph.Server;
 import de.uni_kl.cs.discodnc.numbers.Num;
+import de.uni_kl.cs.discodnc.tandem.AnalysisResults;
 
-public class TotalFlowResults extends AnalysisResults {
-    protected Map<Server, Set<Num>> map__server__D_server;
-    protected Map<Server, Set<Num>> map__server__B_server;
+public class SeparateFlowResults extends AnalysisResults {
+    protected Set<ServiceCurve> betas_e2e;
+    protected Map<Server, Set<ServiceCurve>> map__server__betas_lo;
 
-    protected TotalFlowResults() {
+    protected SeparateFlowResults() {
         super();
-        map__server__D_server = new HashMap<Server, Set<Num>>();
-        map__server__B_server = new HashMap<Server, Set<Num>>();
+        betas_e2e = new HashSet<ServiceCurve>();
+        map__server__betas_lo = new HashMap<Server, Set<ServiceCurve>>();
     }
 
-    protected TotalFlowResults(Num delay_bound, Map<Server, Set<Num>> map__server__D_server, Num backlog_bound,
-                               Map<Server, Set<Num>> map__server__B_server, Map<Server, Set<ArrivalCurve>> map__server__alphas) {
+    protected SeparateFlowResults(Num delay_bound, Num backlog_bound, Set<ServiceCurve> betas_e2e,
+                                  Map<Server, Set<ServiceCurve>> map__server__betas_lo, Map<Server, Set<ArrivalCurve>> map__server__alphas) {
 
         super(delay_bound, backlog_bound, map__server__alphas);
 
-        this.map__server__D_server = map__server__D_server;
-        this.map__server__B_server = map__server__B_server;
-    }
-
-    public String getServerDelayBoundMapString() {
-        if (map__server__D_server.isEmpty()) {
-            return "{}";
-        }
-
-        StringBuffer result_str = new StringBuffer("{");
-        for (Entry<Server, Set<Num>> entry : map__server__D_server.entrySet()) {
-            result_str.append(entry.getKey().toShortString());
-            result_str.append("={");
-            for (Num delay_bound : entry.getValue()) {
-                result_str.append(delay_bound.toString());
-                result_str.append(",");
-            }
-            result_str.deleteCharAt(result_str.length() - 1); // Remove the trailing comma.
-            result_str.append("}");
-            result_str.append(", ");
-        }
-        result_str.delete(result_str.length() - 2, result_str.length()); // Remove the trailing blank space and comma.
-        result_str.append("}");
-
-        return result_str.toString();
+        this.betas_e2e = betas_e2e;
+        this.map__server__betas_lo = map__server__betas_lo;
     }
 
     @Override
@@ -91,18 +71,27 @@ public class TotalFlowResults extends AnalysisResults {
     protected void setBacklogBound(Num backlog_bound) {
         super.setBacklogBound(backlog_bound);
     }
+    
+    public Set<ServiceCurve> getBetasE2E() {
+    	return Collections.unmodifiableSet(betas_e2e);
+    }
+    
+    public Map<Server, Set<ServiceCurve>> getBetasServerMap() {
+    	return Collections.unmodifiableMap(map__server__betas_lo);
+    }
 
-    public String getServerBacklogBoundMapString() {
-        if (map__server__B_server.isEmpty()) {
+    public String getServerLeftOverBetasMapString() {
+        if (map__server__betas_lo.isEmpty()) {
             return "{}";
         }
 
         StringBuffer result_str = new StringBuffer("{");
-        for (Entry<Server, Set<Num>> entry : map__server__B_server.entrySet()) {
+
+        for (Entry<Server, Set<ServiceCurve>> entry : map__server__betas_lo.entrySet()) {
             result_str.append(entry.getKey().toShortString());
             result_str.append("={");
-            for (Num delay_bound : entry.getValue()) {
-                result_str.append(delay_bound.toString());
+            for (ServiceCurve beta_lo : entry.getValue()) {
+                result_str.append(beta_lo.toString());
                 result_str.append(",");
             }
             result_str.deleteCharAt(result_str.length() - 1); // Remove the trailing comma.
@@ -110,6 +99,7 @@ public class TotalFlowResults extends AnalysisResults {
             result_str.append(", ");
         }
         result_str.delete(result_str.length() - 2, result_str.length()); // Remove the trailing blank space and comma.
+
         result_str.append("}");
 
         return result_str.toString();

--- a/src/main/java/de/uni_kl/cs/discodnc/tandem/analyses/TandemMatchingAnalysis.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/tandem/analyses/TandemMatchingAnalysis.java
@@ -26,7 +26,7 @@
  *
  */
 
-package de.uni_kl.cs.discodnc.feedforward.analyses;
+package de.uni_kl.cs.discodnc.tandem.analyses;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -36,18 +36,18 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Map.Entry;
 
+import de.uni_kl.cs.discodnc.AnalysisConfig;
 import de.uni_kl.cs.discodnc.Calculator;
+import de.uni_kl.cs.discodnc.AnalysisConfig.Multiplexing;
+import de.uni_kl.cs.discodnc.AnalysisConfig.MuxDiscipline;
 import de.uni_kl.cs.discodnc.bounds.disco.pwaffine.Bound;
 import de.uni_kl.cs.discodnc.numbers.Num;
+import de.uni_kl.cs.discodnc.tandem.AbstractAnalysis;
+import de.uni_kl.cs.discodnc.tandem.Analysis;
 import de.uni_kl.cs.discodnc.curves.ArrivalCurve;
 import de.uni_kl.cs.discodnc.curves.Curve;
 import de.uni_kl.cs.discodnc.curves.ServiceCurve;
-import de.uni_kl.cs.discodnc.feedforward.AbstractAnalysis;
-import de.uni_kl.cs.discodnc.feedforward.Analysis;
-import de.uni_kl.cs.discodnc.feedforward.AnalysisConfig;
 import de.uni_kl.cs.discodnc.feedforward.ArrivalBoundDispatch;
-import de.uni_kl.cs.discodnc.feedforward.AnalysisConfig.Multiplexing;
-import de.uni_kl.cs.discodnc.feedforward.AnalysisConfig.MuxDiscipline;
 import de.uni_kl.cs.discodnc.network.server_graph.Flow;
 import de.uni_kl.cs.discodnc.network.server_graph.Path;
 import de.uni_kl.cs.discodnc.network.server_graph.Server;

--- a/src/main/java/de/uni_kl/cs/discodnc/tandem/analyses/TandemMatchingResults.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/tandem/analyses/TandemMatchingResults.java
@@ -1,12 +1,12 @@
-package de.uni_kl.cs.discodnc.feedforward.analyses;
+package de.uni_kl.cs.discodnc.tandem.analyses;
 
 import java.util.Map;
 import java.util.Set;
 
 import de.uni_kl.cs.discodnc.numbers.Num;
+import de.uni_kl.cs.discodnc.tandem.AnalysisResults;
 import de.uni_kl.cs.discodnc.curves.ArrivalCurve;
 import de.uni_kl.cs.discodnc.curves.ServiceCurve;
-import de.uni_kl.cs.discodnc.feedforward.AnalysisResults;
 import de.uni_kl.cs.discodnc.network.server_graph.Server;
 
 public class TandemMatchingResults extends AnalysisResults {

--- a/src/main/java/de/uni_kl/cs/discodnc/tandem/analyses/TotalFlowAnalysis.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/tandem/analyses/TotalFlowAnalysis.java
@@ -28,27 +28,27 @@
  *
  */
 
-package de.uni_kl.cs.discodnc.feedforward.analyses;
+package de.uni_kl.cs.discodnc.tandem.analyses;
 
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import de.uni_kl.cs.discodnc.AnalysisConfig;
 import de.uni_kl.cs.discodnc.Calculator;
+import de.uni_kl.cs.discodnc.AnalysisConfig.Multiplexing;
+import de.uni_kl.cs.discodnc.AnalysisConfig.MuxDiscipline;
 import de.uni_kl.cs.discodnc.bounds.disco.pwaffine.Bound;
 import de.uni_kl.cs.discodnc.curves.ArrivalCurve;
 import de.uni_kl.cs.discodnc.curves.ServiceCurve;
-import de.uni_kl.cs.discodnc.feedforward.AbstractAnalysis;
-import de.uni_kl.cs.discodnc.feedforward.Analysis;
-import de.uni_kl.cs.discodnc.feedforward.AnalysisConfig;
 import de.uni_kl.cs.discodnc.feedforward.ArrivalBoundDispatch;
-import de.uni_kl.cs.discodnc.feedforward.AnalysisConfig.Multiplexing;
-import de.uni_kl.cs.discodnc.feedforward.AnalysisConfig.MuxDiscipline;
 import de.uni_kl.cs.discodnc.network.server_graph.Flow;
 import de.uni_kl.cs.discodnc.network.server_graph.Path;
 import de.uni_kl.cs.discodnc.network.server_graph.Server;
 import de.uni_kl.cs.discodnc.network.server_graph.ServerGraph;
 import de.uni_kl.cs.discodnc.numbers.Num;
+import de.uni_kl.cs.discodnc.tandem.AbstractAnalysis;
+import de.uni_kl.cs.discodnc.tandem.Analysis;
 
 import org.apache.commons.math3.util.Pair;
 

--- a/src/main/java/de/uni_kl/cs/discodnc/tandem/analyses/TotalFlowResults.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/tandem/analyses/TotalFlowResults.java
@@ -28,38 +28,58 @@
  *
  */
 
-package de.uni_kl.cs.discodnc.feedforward.analyses;
+package de.uni_kl.cs.discodnc.tandem.analyses;
 
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
 import de.uni_kl.cs.discodnc.curves.ArrivalCurve;
-import de.uni_kl.cs.discodnc.curves.ServiceCurve;
-import de.uni_kl.cs.discodnc.feedforward.AnalysisResults;
 import de.uni_kl.cs.discodnc.network.server_graph.Server;
 import de.uni_kl.cs.discodnc.numbers.Num;
+import de.uni_kl.cs.discodnc.tandem.AnalysisResults;
 
-public class SeparateFlowResults extends AnalysisResults {
-    protected Set<ServiceCurve> betas_e2e;
-    protected Map<Server, Set<ServiceCurve>> map__server__betas_lo;
+public class TotalFlowResults extends AnalysisResults {
+    protected Map<Server, Set<Num>> map__server__D_server;
+    protected Map<Server, Set<Num>> map__server__B_server;
 
-    protected SeparateFlowResults() {
+    protected TotalFlowResults() {
         super();
-        betas_e2e = new HashSet<ServiceCurve>();
-        map__server__betas_lo = new HashMap<Server, Set<ServiceCurve>>();
+        map__server__D_server = new HashMap<Server, Set<Num>>();
+        map__server__B_server = new HashMap<Server, Set<Num>>();
     }
 
-    protected SeparateFlowResults(Num delay_bound, Num backlog_bound, Set<ServiceCurve> betas_e2e,
-                                  Map<Server, Set<ServiceCurve>> map__server__betas_lo, Map<Server, Set<ArrivalCurve>> map__server__alphas) {
+    protected TotalFlowResults(Num delay_bound, Map<Server, Set<Num>> map__server__D_server, Num backlog_bound,
+                               Map<Server, Set<Num>> map__server__B_server, Map<Server, Set<ArrivalCurve>> map__server__alphas) {
 
         super(delay_bound, backlog_bound, map__server__alphas);
 
-        this.betas_e2e = betas_e2e;
-        this.map__server__betas_lo = map__server__betas_lo;
+        this.map__server__D_server = map__server__D_server;
+        this.map__server__B_server = map__server__B_server;
+    }
+
+    public String getServerDelayBoundMapString() {
+        if (map__server__D_server.isEmpty()) {
+            return "{}";
+        }
+
+        StringBuffer result_str = new StringBuffer("{");
+        for (Entry<Server, Set<Num>> entry : map__server__D_server.entrySet()) {
+            result_str.append(entry.getKey().toShortString());
+            result_str.append("={");
+            for (Num delay_bound : entry.getValue()) {
+                result_str.append(delay_bound.toString());
+                result_str.append(",");
+            }
+            result_str.deleteCharAt(result_str.length() - 1); // Remove the trailing comma.
+            result_str.append("}");
+            result_str.append(", ");
+        }
+        result_str.delete(result_str.length() - 2, result_str.length()); // Remove the trailing blank space and comma.
+        result_str.append("}");
+
+        return result_str.toString();
     }
 
     @Override
@@ -71,27 +91,18 @@ public class SeparateFlowResults extends AnalysisResults {
     protected void setBacklogBound(Num backlog_bound) {
         super.setBacklogBound(backlog_bound);
     }
-    
-    public Set<ServiceCurve> getBetasE2E() {
-    	return Collections.unmodifiableSet(betas_e2e);
-    }
-    
-    public Map<Server, Set<ServiceCurve>> getBetasServerMap() {
-    	return Collections.unmodifiableMap(map__server__betas_lo);
-    }
 
-    public String getServerLeftOverBetasMapString() {
-        if (map__server__betas_lo.isEmpty()) {
+    public String getServerBacklogBoundMapString() {
+        if (map__server__B_server.isEmpty()) {
             return "{}";
         }
 
         StringBuffer result_str = new StringBuffer("{");
-
-        for (Entry<Server, Set<ServiceCurve>> entry : map__server__betas_lo.entrySet()) {
+        for (Entry<Server, Set<Num>> entry : map__server__B_server.entrySet()) {
             result_str.append(entry.getKey().toShortString());
             result_str.append("={");
-            for (ServiceCurve beta_lo : entry.getValue()) {
-                result_str.append(beta_lo.toString());
+            for (Num delay_bound : entry.getValue()) {
+                result_str.append(delay_bound.toString());
                 result_str.append(",");
             }
             result_str.deleteCharAt(result_str.length() - 1); // Remove the trailing comma.
@@ -99,7 +110,6 @@ public class SeparateFlowResults extends AnalysisResults {
             result_str.append(", ");
         }
         result_str.delete(result_str.length() - 2, result_str.length()); // Remove the trailing blank space and comma.
-
         result_str.append("}");
 
         return result_str.toString();


### PR DESCRIPTION
The feedforward package now only contains the arrival bounding code that is able to backtrack through any feedforward network. The code for classical tandem analyses (TFA, SFA, PMOO) was split out and put into a separate "tandem" package. This change also required to move the AnalysisConfig into the common (logical) parent package as it brings both parts of an analysis together. The presets class moved there, too.
The sink-tree specific arrival bound was separated into a new sinktree package as well. Commented code about making it extend the feedforward ArrivalBound was removed.