### PR TITLE
Better naming for Calculator Methods and Member Variables

### DIFF
--- a/src/main/java/de/uni_kl/cs/discodnc/Calculator.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/Calculator.java
@@ -34,8 +34,10 @@ import de.uni_kl.cs.discodnc.numbers.NumBackend;
 
 public final class Calculator {
 	private static Calculator instance = new Calculator();
-	private AlgDncBackend CURVE_BACKEND = AlgDncBackend_DNC_PwAffine.DISCO_PWAFFINE;
+	
 	private NumBackend NUM_BACKEND = NumBackend.REAL_DOUBLE_PRECISION;
+	
+	private AlgDncBackend DNC_BACKEND = AlgDncBackend_DNC_PwAffine.DISCO_PWAFFINE;
 	
 	private boolean ARRIVAL_CURVE_CHECKS = false;
 	private boolean SERVICE_CURVE_CHECKS = false;
@@ -54,29 +56,38 @@ public final class Calculator {
 		return NUM_BACKEND;
 	}
 
-	public boolean setNumBackend(NumBackend backend) {
-		if (NUM_BACKEND == backend) {
+	public boolean setNumBackend(NumBackend num_backend) {
+		if (NUM_BACKEND == num_backend) {
 			return false;
 		} else {
-			NUM_BACKEND = backend;
+			NUM_BACKEND = num_backend;
 			return true;
 		}
 	}
 
-	public AlgDncBackend getCurveBackend() {
-		return CURVE_BACKEND;
+	public AlgDncBackend getDncBackend() {
+		return DNC_BACKEND;
+	}
+	
+	public Curve getCurveFactory() {
+		return DNC_BACKEND.getCurveFactory();
+	}
+	
+	public MinPlus getMinPlus() {
+		return DNC_BACKEND.getMinPlus();
 	}
 
 	private void checkDependencies() {
-		CURVE_BACKEND.checkDependencies();
+		DNC_BACKEND.checkDependencies();
 	}
-	public boolean setCurveBackend(AlgDncBackend curve_backend) {
+	
+	public boolean setCurveBackend(AlgDncBackend alg_dnc_backend) {
 		checkDependencies();
 
-		if (CURVE_BACKEND == curve_backend) {
+		if (DNC_BACKEND == alg_dnc_backend) {
 			return false;
 		}
-		CURVE_BACKEND = curve_backend;
+		DNC_BACKEND = alg_dnc_backend;
 		return true;
 	}
 
@@ -122,7 +133,8 @@ public final class Calculator {
 
 		calculator_config_str.append(getNumBackend().toString());
 		calculator_config_str.append(", ");
-		calculator_config_str.append(getCurveBackend().toString());
+		
+		calculator_config_str.append(getDncBackend().toString());
 
 		if (exec_arrival_curve_checks()) {
 			calculator_config_str.append(", ");
@@ -146,13 +158,5 @@ public final class Calculator {
 		}
 
 		return calculator_config_str.toString();
-	}
-	
-	public MinPlus getMinPlus() {
-		return CURVE_BACKEND.getMinPlus();
-	}
-	
-	public Curve getCurve() {
-		return CURVE_BACKEND.getCurveFactory();
 	}
 }

--- a/src/main/java/de/uni_kl/cs/discodnc/curves/Curve.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/curves/Curve.java
@@ -48,7 +48,7 @@ public interface Curve {
     // --------------------------------------------------------------------------------------------------------------
 
     static Curve getFactory() {
-        return Calculator.getInstance().getCurve();
+        return Calculator.getInstance().getCurveFactory();
     }
 
     // --------------------------------------------------------------------------------------------------------------

--- a/src/main/java/de/uni_kl/cs/discodnc/curves/LinearSegment.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/curves/LinearSegment.java
@@ -33,12 +33,12 @@ import de.uni_kl.cs.discodnc.numbers.Num;
 public interface LinearSegment {
 	
 	static LinearSegment createLinearSegment(Num x, Num y, Num grad, boolean leftopen) {
-		LinearSegment.Builder builder = Calculator.getInstance().getCurveBackend().getLinearSegmentFactory();
+		LinearSegment.Builder builder = Calculator.getInstance().getDncBackend().getLinearSegmentFactory();
         return builder.createLinearSegment(x, y, grad, leftopen);
     }
 
     static LinearSegment createHorizontalLine(double y) {
-    	LinearSegment.Builder builder = Calculator.getInstance().getCurveBackend().getLinearSegmentFactory();
+    	LinearSegment.Builder builder = Calculator.getInstance().getDncBackend().getLinearSegmentFactory();
         return builder.createHorizontalLine(y);
     }
 

--- a/src/main/java/de/uni_kl/cs/discodnc/feedforward/arrivalbounds/AggregatePboo_Concatenation.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/feedforward/arrivalbounds/AggregatePboo_Concatenation.java
@@ -164,7 +164,7 @@ public class AggregatePboo_Concatenation extends AbstractArrivalBound implements
 
 		// TODO This implementation only works for token-bucket arrivals. 
 		if (configuration.serverBacklogArrivalBound()
-				&& Calculator.getInstance().getCurveBackend() == AlgDncBackend_DNC_Affine.DISCO_AFFINE) {
+				&& Calculator.getInstance().getDncBackend() == AlgDncBackend_DNC_Affine.DISCO_AFFINE) {
 			Server last_hop_xtx = turn.getSource();
 			// For the DiscoDNC, it is easiest to use TFA to compute the server's backlog bound. 
 			TotalFlowAnalysis tfa = new TotalFlowAnalysis(server_graph, configuration);

--- a/src/main/java/de/uni_kl/cs/discodnc/feedforward/arrivalbounds/AggregatePboo_PerServer.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/feedforward/arrivalbounds/AggregatePboo_PerServer.java
@@ -158,7 +158,7 @@ public class AggregatePboo_PerServer extends AbstractArrivalBound implements Arr
 		// TODO This implementation only works for token-bucket arrivals. 
 		// It disregards the potential shift in inflection points not present in this burst cap variant.
 		if (configuration.serverBacklogArrivalBound()
-				&& Calculator.getInstance().getCurveBackend() == AlgDncBackend_DNC_Affine.DISCO_AFFINE) {
+				&& Calculator.getInstance().getDncBackend() == AlgDncBackend_DNC_Affine.DISCO_AFFINE) {
 			Server last_hop_xtx = turn.getSource();
 			// For the DiscoDNC, it is easiest to use TFA to compute the server's backlog bound. 
 			TotalFlowAnalysis tfa = new TotalFlowAnalysis(server_graph, configuration);

--- a/src/main/java/de/uni_kl/cs/discodnc/feedforward/arrivalbounds/AggregateTandemMatching.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/feedforward/arrivalbounds/AggregateTandemMatching.java
@@ -147,7 +147,7 @@ public class AggregateTandemMatching extends AbstractArrivalBound implements Arr
 		// TODO This implementation only works for token-bucket arrivals. 
 		// It disregards the potential shift in inflection points not present in this burst cap variant.
 		if (configuration.serverBacklogArrivalBound()
-				&& Calculator.getInstance().getCurveBackend() == AlgDncBackend_DNC_Affine.DISCO_AFFINE) {
+				&& Calculator.getInstance().getDncBackend() == AlgDncBackend_DNC_Affine.DISCO_AFFINE) {
 			Server last_hop_xtx = turn.getSource();
 			TotalFlowAnalysis tfa = new TotalFlowAnalysis(server_graph, configuration);
 			tfa.deriveBoundsAtServer(last_hop_xtx);

--- a/src/main/java/de/uni_kl/cs/discodnc/tandem/analyses/PmooAnalysis.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/tandem/analyses/PmooAnalysis.java
@@ -205,7 +205,7 @@ public class PmooAnalysis extends AbstractAnalysis implements Analysis {
             }
 
             Curve tmpcurve = service_curves[i].getRL_Component(server_rl_iters[i]);
-            ServiceCurve current_rl = Calculator.getInstance().getCurve().createServiceCurve(tmpcurve);
+            ServiceCurve current_rl = Calculator.getInstance().getCurveFactory().createServiceCurve(tmpcurve);
 
             // Sum up latencies
             T = compute.add(T, current_rl.getLatency());
@@ -215,7 +215,7 @@ public class PmooAnalysis extends AbstractAnalysis implements Analysis {
             for (Flow f : present_flows) {
                 ArrivalCurve bound = f.getArrivalCurve();
                 Curve ac = bound.getTB_Component(((Integer) flow_tb_iter_map.get(f)).intValue());
-                ArrivalCurve current_tb = Calculator.getInstance().getCurve().createArrivalCurve(ac);
+                ArrivalCurve current_tb = Calculator.getInstance().getCurveFactory().createArrivalCurve(ac);
                 sum_r = compute.add(sum_r, current_tb.getUltAffineRate());
             }
 
@@ -244,7 +244,7 @@ public class PmooAnalysis extends AbstractAnalysis implements Analysis {
         for (Flow f : cross_flow_substitutes) {
             ArrivalCurve bound = f.getArrivalCurve();
             Curve ac = bound.getTB_Component(((Integer) flow_tb_iter_map.get(f)).intValue());
-            ArrivalCurve current_tb = Calculator.getInstance().getCurve().createArrivalCurve(ac);
+            ArrivalCurve current_tb = Calculator.getInstance().getCurveFactory().createArrivalCurve(ac);
             sum_bursts = compute.add(sum_bursts, current_tb.getBurst());
         }
 


### PR DESCRIPTION
getCurve() actually returned a CurveFactory whereas getCurveBackend() returned the entire algebraic DNC backend (memebr variable name had not caught up to the class name). To further improve separation by name, num_ prefixes were added for to the few number backend variables in the Calculator class, too.

I also checked calls to getCurveBackend(), now getDncBackend(), to check if they were followed by getting a curve factory. I did not find such a chaining of calls, i.e., no simplifications to be made w.r.t. to this.