### PR TITLE
Make bound/util classes abstract + cleanups

### DIFF
--- a/src/main/java/de/uni_kl/cs/discodnc/bounds/disco/pwaffine/Backlog.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/bounds/disco/pwaffine/Backlog.java
@@ -43,7 +43,7 @@ import de.uni_kl.cs.discodnc.network.server_graph.Turn;
 import de.uni_kl.cs.discodnc.numbers.Num;
 import de.uni_kl.cs.discodnc.sinktree.arrivalbounds.SinkTree_AffineCurves;
 
-public abstract class Backlog {
+public final class Backlog {
 	public static Num derive(ArrivalCurve arrival_curve, ServiceCurve service_curve) {
 		if (arrival_curve.equals(Curve.getFactory().createZeroArrivals())) {
 			return Num.getFactory(Calculator.getInstance().getNumBackend()).createZero();

--- a/src/main/java/de/uni_kl/cs/discodnc/bounds/disco/pwaffine/Bound.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/bounds/disco/pwaffine/Bound.java
@@ -37,7 +37,7 @@ import de.uni_kl.cs.discodnc.network.server_graph.Server;
 import de.uni_kl.cs.discodnc.network.server_graph.ServerGraph;
 import de.uni_kl.cs.discodnc.numbers.Num;
 
-public abstract class Bound {
+public final class Bound {
     // --------------------------------------------------------------------------------------------------------------
     // Backlog
     // --------------------------------------------------------------------------------------------------------------

--- a/src/main/java/de/uni_kl/cs/discodnc/bounds/disco/pwaffine/Delay.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/bounds/disco/pwaffine/Delay.java
@@ -35,7 +35,7 @@ import de.uni_kl.cs.discodnc.curves.Curve;
 import de.uni_kl.cs.discodnc.curves.ServiceCurve;
 import de.uni_kl.cs.discodnc.numbers.Num;
 
-public abstract class Delay {
+public final class Delay {
     private static Num deriveForSpecialCurves(ArrivalCurve arrival_curve, ServiceCurve service_curve) {
         if (arrival_curve.equals(Curve.getFactory().createZeroArrivals())) {
             return Num.getFactory(Calculator.getInstance().getNumBackend()).createZero();

--- a/src/main/java/de/uni_kl/cs/discodnc/bounds/disco/pwaffine/LeftOverService.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/bounds/disco/pwaffine/LeftOverService.java
@@ -45,7 +45,7 @@ import de.uni_kl.cs.discodnc.curves.ServiceCurve;
 import de.uni_kl.cs.discodnc.network.server_graph.Server;
 import de.uni_kl.cs.discodnc.numbers.Num;
 
-public abstract class LeftOverService {
+public final class LeftOverService {
     public static Set<ServiceCurve> compute(AnalysisConfig configuration, Server server,
                                             Set<ArrivalCurve> arrival_curves) {
         if (configuration.multiplexingDiscipline() == MuxDiscipline.GLOBAL_FIFO

--- a/src/main/java/de/uni_kl/cs/discodnc/bounds/disco/pwaffine/Output.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/bounds/disco/pwaffine/Output.java
@@ -39,7 +39,7 @@ import de.uni_kl.cs.discodnc.curves.ServiceCurve;
 import de.uni_kl.cs.discodnc.network.server_graph.Path;
 import de.uni_kl.cs.discodnc.network.server_graph.Server;
 
-public abstract class Output {
+public final class Output {
     public static Set<ArrivalCurve> compute(AnalysisConfig configuration, Set<ArrivalCurve> arrival_curves,
                                             Server server) throws Exception {
         return compute(configuration, arrival_curves, server, Collections.singleton(server.getServiceCurve()));

--- a/src/main/java/de/uni_kl/cs/discodnc/utils/CheckUtils.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/utils/CheckUtils.java
@@ -31,7 +31,7 @@ import java.util.Set;
 
 import de.uni_kl.cs.discodnc.curves.Curve;
 
-public abstract class CheckUtils {
+public final class CheckUtils {
 
 	// --------------------------------------------------------------------------------------------------------------
 	// Generic Input Checks

--- a/src/main/java/de/uni_kl/cs/discodnc/utils/SetUtils.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/utils/SetUtils.java
@@ -37,7 +37,7 @@ import java.util.Set;
  * A tiny collection of convenience methods useful in dealing with sets but not
  * provided directly by Java's set classes.
  */
-public abstract class SetUtils {
+public final class SetUtils {
     /**
      * Returns the set difference between the set <code>s1</code> and the set
      * <code>s2</code>.


### PR DESCRIPTION
These classes only consist of static methods and are not meant to be instantiated, just as the min-plus algebra implementations. Thus, they are now abstract just like the min plus algebra classes.