### PR TITLE
Cleanups and Fixes for Multiplexing and MaxServiceCurve Code

### DIFF
--- a/src/main/java/de/uni_kl/cs/discodnc/AnalysisConfig.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/AnalysisConfig.java
@@ -46,7 +46,7 @@ public class AnalysisConfig {
         SERVER_LOCAL, GLOBAL_ARBITRARY, GLOBAL_FIFO
     }
 
-    public enum GammaFlag {
+    public enum MaxScEnforcement {
         SERVER_LOCAL, GLOBALLY_ON, GLOBALLY_OFF
     }
 
@@ -61,14 +61,14 @@ public class AnalysisConfig {
     /**
      * Whether to use maximum service curves in output bound computation
      */
-    private GammaFlag use_gamma = GammaFlag.SERVER_LOCAL;
+    private MaxScEnforcement enforce_max_sc = MaxScEnforcement.SERVER_LOCAL;
     
     /**
      * Whether to constrain the output bound further through convolution with the
      * maximum service curve's rate as the server cannot output data faster than
      * this rate.
      */
-    private GammaFlag use_extra_gamma = GammaFlag.SERVER_LOCAL;
+    private MaxScEnforcement enforce_max_sc_output_rate = MaxScEnforcement.SERVER_LOCAL;
     private Set<ArrivalBoundMethod> arrival_bound_methods = new HashSet<ArrivalBoundMethod>(
             Collections.singleton(ArrivalBoundMethod.AGGR_PBOO_CONCATENATION));
     private boolean remove_duplicate_arrival_bounds = true;
@@ -78,12 +78,12 @@ public class AnalysisConfig {
     public AnalysisConfig() {
     }
     
-    public AnalysisConfig(MultiplexingEnforcement enforcement, GammaFlag use_gamma, GammaFlag use_extra_gamma,
+    public AnalysisConfig(MultiplexingEnforcement multiplexing_enforcement, MaxScEnforcement enforce_max_sc, MaxScEnforcement enforce_max_sc_output_rate,
                           Set<ArrivalBoundMethod> arrival_bound_methods, boolean remove_duplicate_arrival_bounds,
                           boolean server_backlog_arrival_bound) {
-        this.multiplexing_enforcement = enforcement;
-        this.use_gamma = use_gamma;
-        this.use_extra_gamma = use_extra_gamma;
+        this.multiplexing_enforcement = multiplexing_enforcement;
+        this.enforce_max_sc = enforce_max_sc;
+        this.enforce_max_sc_output_rate = enforce_max_sc_output_rate;
         this.arrival_bound_methods.clear();
         this.arrival_bound_methods.addAll(arrival_bound_methods);
         this.remove_duplicate_arrival_bounds = remove_duplicate_arrival_bounds;
@@ -98,20 +98,20 @@ public class AnalysisConfig {
         multiplexing_enforcement = enforcement;
     }
 
-    public GammaFlag useGamma() {
-        return use_gamma;
+    public MaxScEnforcement enforceMaxSC() {
+        return enforce_max_sc;
     }
 
-    public void setUseGamma(GammaFlag use_gamma_flag) {
-        use_gamma = use_gamma_flag;
+    public void enforceMaxSC(MaxScEnforcement enforcement) {
+        this.enforce_max_sc = enforcement;
     }
 
-    public GammaFlag useExtraGamma() {
-        return use_extra_gamma;
+    public MaxScEnforcement enforceMaxScOutputRate() {
+        return enforce_max_sc_output_rate;
     }
 
-    public void setUseExtraGamma(GammaFlag use_extra_gamma_flag) {
-        use_extra_gamma = use_extra_gamma_flag;
+    public void enforceMaxScOutputRate(MaxScEnforcement enforcement) {
+        enforce_max_sc_output_rate = enforcement;
     }
 
     public void defaultArrivalBoundMethods() {
@@ -183,7 +183,7 @@ public class AnalysisConfig {
      * @return The copy.
      */
     public AnalysisConfig copy() { // deep copy as primitive data types are copied by value
-        return new AnalysisConfig(multiplexing_enforcement, use_gamma, use_extra_gamma, arrival_bound_methods,
+        return new AnalysisConfig(multiplexing_enforcement, enforce_max_sc, enforce_max_sc_output_rate, arrival_bound_methods,
                 remove_duplicate_arrival_bounds, server_backlog_arrival_bound);
     }
 

--- a/src/main/java/de/uni_kl/cs/discodnc/AnalysisConfig.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/AnalysisConfig.java
@@ -42,7 +42,7 @@ public class AnalysisConfig {
         ARBITRARY, FIFO
     }
 
-    public enum MuxDiscipline {
+    public enum MultiplexingEnforcement {
         SERVER_LOCAL, GLOBAL_ARBITRARY, GLOBAL_FIFO
     }
 
@@ -56,7 +56,7 @@ public class AnalysisConfig {
 		SINKTREE_AFFINE_MINPLUS, SINKTREE_AFFINE_DIRECT, SINKTREE_AFFINE_HOMO
     }
     
-    private MuxDiscipline multiplexing_discipline = MuxDiscipline.SERVER_LOCAL;
+    private MultiplexingEnforcement multiplexing_enforcement = MultiplexingEnforcement.SERVER_LOCAL;
     
     /**
      * Whether to use maximum service curves in output bound computation
@@ -78,10 +78,10 @@ public class AnalysisConfig {
     public AnalysisConfig() {
     }
     
-    public AnalysisConfig(MuxDiscipline multiplexing_discipline, GammaFlag use_gamma, GammaFlag use_extra_gamma,
+    public AnalysisConfig(MultiplexingEnforcement enforcement, GammaFlag use_gamma, GammaFlag use_extra_gamma,
                           Set<ArrivalBoundMethod> arrival_bound_methods, boolean remove_duplicate_arrival_bounds,
                           boolean server_backlog_arrival_bound) {
-        this.multiplexing_discipline = multiplexing_discipline;
+        this.multiplexing_enforcement = enforcement;
         this.use_gamma = use_gamma;
         this.use_extra_gamma = use_extra_gamma;
         this.arrival_bound_methods.clear();
@@ -90,12 +90,12 @@ public class AnalysisConfig {
         this.server_backlog_arrival_bound = server_backlog_arrival_bound;
     }
 
-    public MuxDiscipline multiplexingDiscipline() {
-        return multiplexing_discipline;
+    public MultiplexingEnforcement multiplexingEnforcement() {
+        return multiplexing_enforcement;
     }
 
-    public void setMultiplexingDiscipline(MuxDiscipline mux_discipline) {
-        multiplexing_discipline = mux_discipline;
+    public void setMultiplexingEnforcement(MultiplexingEnforcement enforcement) {
+        multiplexing_enforcement = enforcement;
     }
 
     public GammaFlag useGamma() {
@@ -183,7 +183,7 @@ public class AnalysisConfig {
      * @return The copy.
      */
     public AnalysisConfig copy() { // deep copy as primitive data types are copied by value
-        return new AnalysisConfig(multiplexing_discipline, use_gamma, use_extra_gamma, arrival_bound_methods,
+        return new AnalysisConfig(multiplexing_enforcement, use_gamma, use_extra_gamma, arrival_bound_methods,
                 remove_duplicate_arrival_bounds, server_backlog_arrival_bound);
     }
 
@@ -191,7 +191,7 @@ public class AnalysisConfig {
     public String toString() {
         StringBuffer analysis_config_str = new StringBuffer();
 
-        analysis_config_str.append(multiplexingDiscipline().toString());
+        analysis_config_str.append(multiplexingEnforcement().toString());
         analysis_config_str.append(", ");
         analysis_config_str.append(arrivalBoundMethods().toString());
 

--- a/src/main/java/de/uni_kl/cs/discodnc/AnalysisConfig.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/AnalysisConfig.java
@@ -90,11 +90,11 @@ public class AnalysisConfig {
         this.server_backlog_arrival_bound = server_backlog_arrival_bound;
     }
 
-    public MultiplexingEnforcement multiplexingEnforcement() {
+    public MultiplexingEnforcement enforceMultiplexing() {
         return multiplexing_enforcement;
     }
 
-    public void setMultiplexingEnforcement(MultiplexingEnforcement enforcement) {
+    public void enforceMultiplexing(MultiplexingEnforcement enforcement) {
         multiplexing_enforcement = enforcement;
     }
 
@@ -191,7 +191,7 @@ public class AnalysisConfig {
     public String toString() {
         StringBuffer analysis_config_str = new StringBuffer();
 
-        analysis_config_str.append(multiplexingEnforcement().toString());
+        analysis_config_str.append(enforceMultiplexing().toString());
         analysis_config_str.append(", ");
         analysis_config_str.append(arrivalBoundMethods().toString());
 

--- a/src/main/java/de/uni_kl/cs/discodnc/CompFFApresets.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/CompFFApresets.java
@@ -76,7 +76,7 @@ public class CompFFApresets {
 		base_config.setUseGamma( GammaFlag.GLOBALLY_OFF );
 		base_config.setUseExtraGamma( GammaFlag.GLOBALLY_OFF );
 		
-		base_config.setMultiplexingEnforcement( MultiplexingEnforcement.GLOBAL_ARBITRARY );
+		base_config.enforceMultiplexing( MultiplexingEnforcement.GLOBAL_ARBITRARY );
 
 		
 		// --------------------------------------------------------------------------------------------------------------

--- a/src/main/java/de/uni_kl/cs/discodnc/CompFFApresets.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/CompFFApresets.java
@@ -4,7 +4,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import de.uni_kl.cs.discodnc.AnalysisConfig.ArrivalBoundMethod;
-import de.uni_kl.cs.discodnc.AnalysisConfig.GammaFlag;
+import de.uni_kl.cs.discodnc.AnalysisConfig.MaxScEnforcement;
 import de.uni_kl.cs.discodnc.AnalysisConfig.MultiplexingEnforcement;
 import de.uni_kl.cs.discodnc.network.server_graph.ServerGraph;
 import de.uni_kl.cs.discodnc.tandem.analyses.PmooAnalysis;
@@ -73,8 +73,8 @@ public class CompFFApresets {
 		AnalysisConfig base_config = new AnalysisConfig();
 		base_config.setRemoveDuplicateArrivalBounds( true );
 		
-		base_config.setUseGamma( GammaFlag.GLOBALLY_OFF );
-		base_config.setUseExtraGamma( GammaFlag.GLOBALLY_OFF );
+		base_config.enforceMaxSC( MaxScEnforcement.GLOBALLY_OFF );
+		base_config.enforceMaxScOutputRate( MaxScEnforcement.GLOBALLY_OFF );
 		
 		base_config.enforceMultiplexing( MultiplexingEnforcement.GLOBAL_ARBITRARY );
 

--- a/src/main/java/de/uni_kl/cs/discodnc/CompFFApresets.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/CompFFApresets.java
@@ -5,7 +5,7 @@ import java.util.Set;
 
 import de.uni_kl.cs.discodnc.AnalysisConfig.ArrivalBoundMethod;
 import de.uni_kl.cs.discodnc.AnalysisConfig.GammaFlag;
-import de.uni_kl.cs.discodnc.AnalysisConfig.MuxDiscipline;
+import de.uni_kl.cs.discodnc.AnalysisConfig.MultiplexingEnforcement;
 import de.uni_kl.cs.discodnc.network.server_graph.ServerGraph;
 import de.uni_kl.cs.discodnc.tandem.analyses.PmooAnalysis;
 import de.uni_kl.cs.discodnc.tandem.analyses.SeparateFlowAnalysis;
@@ -76,7 +76,7 @@ public class CompFFApresets {
 		base_config.setUseGamma( GammaFlag.GLOBALLY_OFF );
 		base_config.setUseExtraGamma( GammaFlag.GLOBALLY_OFF );
 		
-		base_config.setMultiplexingDiscipline( MuxDiscipline.GLOBAL_ARBITRARY );
+		base_config.setMultiplexingEnforcement( MultiplexingEnforcement.GLOBAL_ARBITRARY );
 
 		
 		// --------------------------------------------------------------------------------------------------------------

--- a/src/main/java/de/uni_kl/cs/discodnc/algebra/MinPlus.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/algebra/MinPlus.java
@@ -55,10 +55,10 @@ public interface MinPlus {
 	MaxServiceCurve convolve(MaxServiceCurve max_service_curve_1, MaxServiceCurve max_service_curve_2) throws Exception;
 
 	// Arrival Curves and Max Service Curves
-	Set<Curve> convolve_ACs_MSC(Set<ArrivalCurve> arrival_curves, MaxServiceCurve maximum_service_curve)
+	Set<Curve> convolve_ACs_MaxSC(Set<ArrivalCurve> arrival_curves, MaxServiceCurve maximum_service_curve)
 			throws Exception;
 	
-	Set<ArrivalCurve> convolve_ACs_EGamma(Set<ArrivalCurve> arrival_curves, MaxServiceCurve extra_gamma_curve)
+	Set<ArrivalCurve> convolve_ACs_MaxScRate(Set<ArrivalCurve> arrival_curves, MaxServiceCurve extra_gamma_curve)
 			throws Exception;
 	
 	// ------------------------------------------------------------

--- a/src/main/java/de/uni_kl/cs/discodnc/algebra/disco/affine/MinPlus_Disco_Affine.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/algebra/disco/affine/MinPlus_Disco_Affine.java
@@ -96,7 +96,7 @@ public enum MinPlus_Disco_Affine implements MinPlus {
 	 * @see de.uni_kl.cs.discodnc.minplus.IMinPlus#convolve_ACs_MSC(java.util.Set, de.uni_kl.cs.discodnc.curves.MaxServiceCurve)
 	 */
 	@Override
-	public Set<Curve> convolve_ACs_MSC(Set<ArrivalCurve> arrival_curves,
+	public Set<Curve> convolve_ACs_MaxSC(Set<ArrivalCurve> arrival_curves,
 			MaxServiceCurve maximum_service_curve) throws Exception {
 		return Convolution_Disco_Affine.convolve_ACs_MSC(arrival_curves, maximum_service_curve);
 	}
@@ -105,7 +105,7 @@ public enum MinPlus_Disco_Affine implements MinPlus {
 	 * @see de.uni_kl.cs.discodnc.minplus.IMinPlus#convolve_ACs_EGamma(java.util.Set, de.uni_kl.cs.discodnc.curves.MaxServiceCurve)
 	 */
 	@Override
-	public Set<ArrivalCurve> convolve_ACs_EGamma(Set<ArrivalCurve> arrival_curves,
+	public Set<ArrivalCurve> convolve_ACs_MaxScRate(Set<ArrivalCurve> arrival_curves,
 			MaxServiceCurve extra_gamma_curve) throws Exception {
 		return Convolution_Disco_Affine.convolve_ACs_EGamma(arrival_curves, extra_gamma_curve);
 	}

--- a/src/main/java/de/uni_kl/cs/discodnc/algebra/disco/pwaffine/MinPlus_Disco_PwAffine.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/algebra/disco/pwaffine/MinPlus_Disco_PwAffine.java
@@ -96,7 +96,7 @@ public enum MinPlus_Disco_PwAffine implements MinPlus {
 	 * @see de.uni_kl.cs.discodnc.minplus.IMinPlus#convolve_ACs_MSC(java.util.Set, de.uni_kl.cs.discodnc.curves.MaxServiceCurve)
 	 */
 	@Override
-	public Set<Curve> convolve_ACs_MSC(Set<ArrivalCurve> arrival_curves,
+	public Set<Curve> convolve_ACs_MaxSC(Set<ArrivalCurve> arrival_curves,
 			MaxServiceCurve maximum_service_curve) throws Exception {
 		return Convolution_Disco_PwAffine.convolve_ACs_MSC(arrival_curves, maximum_service_curve);
 	}
@@ -105,7 +105,7 @@ public enum MinPlus_Disco_PwAffine implements MinPlus {
 	 * @see de.uni_kl.cs.discodnc.minplus.IMinPlus#convolve_ACs_EGamma(java.util.Set, de.uni_kl.cs.discodnc.curves.MaxServiceCurve)
 	 */
 	@Override
-	public Set<ArrivalCurve> convolve_ACs_EGamma(Set<ArrivalCurve> arrival_curves,
+	public Set<ArrivalCurve> convolve_ACs_MaxScRate(Set<ArrivalCurve> arrival_curves,
 			MaxServiceCurve extra_gamma_curve) throws Exception {
 		return Convolution_Disco_PwAffine.convolve_ACs_EGamma(arrival_curves, extra_gamma_curve);
 	}

--- a/src/main/java/de/uni_kl/cs/discodnc/bounds/disco/pwaffine/LeftOverService.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/bounds/disco/pwaffine/LeftOverService.java
@@ -48,8 +48,8 @@ import de.uni_kl.cs.discodnc.numbers.Num;
 public final class LeftOverService {
     public static Set<ServiceCurve> compute(AnalysisConfig configuration, Server server,
                                             Set<ArrivalCurve> arrival_curves) {
-        if (configuration.multiplexingEnforcement() == MultiplexingEnforcement.GLOBAL_FIFO
-                || (configuration.multiplexingEnforcement() == MultiplexingEnforcement.SERVER_LOCAL
+        if (configuration.enforceMultiplexing() == MultiplexingEnforcement.GLOBAL_FIFO
+                || (configuration.enforceMultiplexing() == MultiplexingEnforcement.SERVER_LOCAL
                 && server.multiplexing() == Multiplexing.FIFO)) {
             return fifoMux(server.getServiceCurve(), arrival_curves);
         } else {
@@ -59,7 +59,7 @@ public final class LeftOverService {
 
     public static Set<ServiceCurve> compute(AnalysisConfig configuration, ServiceCurve service_curve,
                                             Set<ArrivalCurve> arrival_curves) {
-        if (configuration.multiplexingEnforcement() == MultiplexingEnforcement.GLOBAL_FIFO) {
+        if (configuration.enforceMultiplexing() == MultiplexingEnforcement.GLOBAL_FIFO) {
             return LeftOverService.fifoMux(service_curve, arrival_curves);
         } else {
             return LeftOverService.arbMux(service_curve, arrival_curves);

--- a/src/main/java/de/uni_kl/cs/discodnc/bounds/disco/pwaffine/LeftOverService.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/bounds/disco/pwaffine/LeftOverService.java
@@ -38,7 +38,7 @@ import org.apache.commons.math3.util.Pair;
 import de.uni_kl.cs.discodnc.AnalysisConfig;
 import de.uni_kl.cs.discodnc.Calculator;
 import de.uni_kl.cs.discodnc.AnalysisConfig.Multiplexing;
-import de.uni_kl.cs.discodnc.AnalysisConfig.MuxDiscipline;
+import de.uni_kl.cs.discodnc.AnalysisConfig.MultiplexingEnforcement;
 import de.uni_kl.cs.discodnc.curves.ArrivalCurve;
 import de.uni_kl.cs.discodnc.curves.Curve;
 import de.uni_kl.cs.discodnc.curves.ServiceCurve;
@@ -48,9 +48,9 @@ import de.uni_kl.cs.discodnc.numbers.Num;
 public final class LeftOverService {
     public static Set<ServiceCurve> compute(AnalysisConfig configuration, Server server,
                                             Set<ArrivalCurve> arrival_curves) {
-        if (configuration.multiplexingDiscipline() == MuxDiscipline.GLOBAL_FIFO
-                || (configuration.multiplexingDiscipline() == MuxDiscipline.SERVER_LOCAL
-                && server.multiplexingDiscipline() == Multiplexing.FIFO)) {
+        if (configuration.multiplexingEnforcement() == MultiplexingEnforcement.GLOBAL_FIFO
+                || (configuration.multiplexingEnforcement() == MultiplexingEnforcement.SERVER_LOCAL
+                && server.multiplexing() == Multiplexing.FIFO)) {
             return fifoMux(server.getServiceCurve(), arrival_curves);
         } else {
             return LeftOverService.arbMux(server.getServiceCurve(), arrival_curves);
@@ -59,7 +59,7 @@ public final class LeftOverService {
 
     public static Set<ServiceCurve> compute(AnalysisConfig configuration, ServiceCurve service_curve,
                                             Set<ArrivalCurve> arrival_curves) {
-        if (configuration.multiplexingDiscipline() == MuxDiscipline.GLOBAL_FIFO) {
+        if (configuration.multiplexingEnforcement() == MultiplexingEnforcement.GLOBAL_FIFO) {
             return LeftOverService.fifoMux(service_curve, arrival_curves);
         } else {
             return LeftOverService.arbMux(service_curve, arrival_curves);

--- a/src/main/java/de/uni_kl/cs/discodnc/bounds/disco/pwaffine/Output.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/bounds/disco/pwaffine/Output.java
@@ -34,50 +34,99 @@ import java.util.Set;
 
 import de.uni_kl.cs.discodnc.AnalysisConfig;
 import de.uni_kl.cs.discodnc.Calculator;
+import de.uni_kl.cs.discodnc.algebra.MinPlus;
 import de.uni_kl.cs.discodnc.curves.ArrivalCurve;
 import de.uni_kl.cs.discodnc.curves.ServiceCurve;
 import de.uni_kl.cs.discodnc.network.server_graph.Path;
 import de.uni_kl.cs.discodnc.network.server_graph.Server;
 
 public final class Output {
-    public static Set<ArrivalCurve> compute(AnalysisConfig configuration, Set<ArrivalCurve> arrival_curves,
-                                            Server server) throws Exception {
+    public static Set<ArrivalCurve> compute(AnalysisConfig configuration, 
+    										Set<ArrivalCurve> arrival_curves, Server server) throws Exception {
         return compute(configuration, arrival_curves, server, Collections.singleton(server.getServiceCurve()));
     }
 
     public static Set<ArrivalCurve> compute(AnalysisConfig configuration, Set<ArrivalCurve> arrival_curves,
                                             Server server, Set<ServiceCurve> betas_lo) throws Exception {
-        Set<ArrivalCurve> result = new HashSet<ArrivalCurve>();
+        Set<ArrivalCurve> output_bound = new HashSet<ArrivalCurve>();
 
-        if (configuration.useGamma() != AnalysisConfig.GammaFlag.GLOBALLY_OFF) {
-            result = Calculator.getInstance().getMinPlus().deconvolve_almostConcCs_SCs(
-                    Calculator.getInstance().getMinPlus().convolve_ACs_MSC(arrival_curves, server.getGamma()), betas_lo);
-        } else {
-            result = Calculator.getInstance().getMinPlus().deconvolve(arrival_curves, betas_lo);
-        }
+        MinPlus minplus_alg = Calculator.getInstance().getMinPlus();
+        
+        switch(configuration.enforceMaxSC()) {
+	    	case GLOBALLY_ON:
+	    		output_bound = minplus_alg.deconvolve_almostConcCs_SCs(
+	    				minplus_alg.convolve_ACs_MaxSC(arrival_curves, server.getStoredMaxSC()), betas_lo);
+	    		break;
+	    		
+	    	case GLOBALLY_OFF:	
+	    		output_bound = minplus_alg.deconvolve(arrival_curves, betas_lo);
+	    		break;
+	    		
+			case SERVER_LOCAL:
+			default:
+				output_bound = minplus_alg.deconvolve_almostConcCs_SCs(
+						minplus_alg.convolve_ACs_MaxSC(arrival_curves, server.getMaxServiceCurve()), betas_lo);
+				break;
+	    }
+        
+        switch(configuration.enforceMaxScOutputRate()) {
+	    	case GLOBALLY_ON:
+	    		output_bound = minplus_alg.convolve_ACs_MaxScRate(output_bound, server.getStoredMaxScRate());
+	    		break;
+	    		
+	    	case GLOBALLY_OFF:	
+	    		// Do nothing
+	    		break;
+	    		
+			case SERVER_LOCAL:
+			default:
+				// Server's flag will be checked in server.getMaxScRate()
+				output_bound = minplus_alg.convolve_ACs_MaxScRate(output_bound, server.getMaxScRate());
+				break;
+	    }
 
-        if (configuration.useExtraGamma() != AnalysisConfig.GammaFlag.GLOBALLY_OFF) {
-            result = Calculator.getInstance().getMinPlus().convolve_ACs_EGamma(result, server.getExtraGamma());
-        }
-
-        return result;
+        return output_bound;
     }
 
-    public static Set<ArrivalCurve> compute(AnalysisConfig configuration, Set<ArrivalCurve> arrival_curves, Path path,
-                                            Set<ServiceCurve> betas_lo) throws Exception {
-        Set<ArrivalCurve> result = new HashSet<ArrivalCurve>();
+    public static Set<ArrivalCurve> compute(AnalysisConfig configuration, 
+    										Set<ArrivalCurve> arrival_curves, Path path, Set<ServiceCurve> betas_lo) throws Exception {
+    	Set<ArrivalCurve> output_bound = new HashSet<ArrivalCurve>();
 
-        if (configuration.useGamma() != AnalysisConfig.GammaFlag.GLOBALLY_OFF) {
-            result = Calculator.getInstance().getMinPlus().deconvolve_almostConcCs_SCs(
-                    Calculator.getInstance().getMinPlus().convolve_ACs_MSC(arrival_curves, path.getGamma()), betas_lo);
-        } else {
-            result = Calculator.getInstance().getMinPlus().deconvolve(arrival_curves, betas_lo);
-        }
+    	MinPlus minplus_alg = Calculator.getInstance().getMinPlus();
+        
+        switch(configuration.enforceMaxSC()) {
+	    	case GLOBALLY_ON:
+	    		output_bound = minplus_alg.deconvolve_almostConcCs_SCs(
+	    				minplus_alg.convolve_ACs_MaxSC(arrival_curves, path.getStoredMaxSC()), betas_lo);
+	    		break;
+	    		
+	    	case GLOBALLY_OFF:	
+	    		output_bound = minplus_alg.deconvolve(arrival_curves, betas_lo);
+	    		break;
+	    		
+			case SERVER_LOCAL:
+			default:
+				output_bound = minplus_alg.deconvolve_almostConcCs_SCs(
+						minplus_alg.convolve_ACs_MaxSC(arrival_curves, path.getMaxServiceCurve()), betas_lo);
+				break;
+	    }
+        
+        switch(configuration.enforceMaxScOutputRate()) {
+	    	case GLOBALLY_ON:
+	    		output_bound = minplus_alg.convolve_ACs_MaxScRate(output_bound, path.getStoredMaxScRate());
+	    		break;
+	    		
+	    	case GLOBALLY_OFF:	
+	    		// Do nothing
+	    		break;
+	    		
+			case SERVER_LOCAL:
+			default:
+				// Server's flag will be checked in path.getMaxScRate()
+				output_bound = minplus_alg.convolve_ACs_MaxScRate(output_bound, path.getMaxScRate());
+				break;
+	    }
 
-        if (configuration.useExtraGamma() != AnalysisConfig.GammaFlag.GLOBALLY_OFF) {
-            result = Calculator.getInstance().getMinPlus().convolve_ACs_EGamma(result, path.getExtraGamma());
-        }
-
-        return result;
+        return output_bound;
     }
 }

--- a/src/main/java/de/uni_kl/cs/discodnc/demos/Demo1.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/demos/Demo1.java
@@ -67,12 +67,12 @@ public class Demo1 {
         Server s0 = network.addServer(service_curve, max_service_curve);
         // Creating a server with a maximum service curve automatically triggers the
         // following setting
-        // s0.setUseGamma( true );
-        // s0.setUseExtraGamma( true );
+        // s0.useMaxSC( true );
+        // s0.useMaxScRate( true );
         // , however, disabling the use of a maximum service curve in a configuration
         // overrides it.
-        configuration.setUseGamma(AnalysisConfig.GammaFlag.GLOBALLY_ON);
-        configuration.setUseExtraGamma(AnalysisConfig.GammaFlag.GLOBALLY_ON);
+        configuration.enforceMaxSC(AnalysisConfig.MaxScEnforcement.GLOBALLY_ON);
+        configuration.enforceMaxScOutputRate(AnalysisConfig.MaxScEnforcement.GLOBALLY_ON);
 
         Flow flow_of_interest = network.addFlow(arrival_curve, s0);
 

--- a/src/main/java/de/uni_kl/cs/discodnc/demos/Demo2.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/demos/Demo2.java
@@ -61,12 +61,12 @@ public class Demo2 {
         ServerGraph network = new ServerGraph();
 
         Server s0 = network.addServer(service_curve, max_service_curve);
-        s0.setUseGamma(false);
-        s0.setUseExtraGamma(false);
+        s0.useMaxSC(false);
+        s0.useMaxScRate(false);
 
         Server s1 = network.addServer(service_curve, max_service_curve);
-        s1.setUseGamma(false);
-        s1.setUseExtraGamma(false);
+        s1.useMaxSC(false);
+        s1.useMaxScRate(false);
 
         network.addTurn(s0, s1);
 

--- a/src/main/java/de/uni_kl/cs/discodnc/demos/Demo3.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/demos/Demo3.java
@@ -61,12 +61,12 @@ public class Demo3 {
         ServerGraph network = new ServerGraph();
 
         Server s0 = network.addServer(service_curve, max_service_curve);
-        s0.setUseGamma(false);
-        s0.setUseExtraGamma(false);
+        s0.useMaxSC(false);
+        s0.useMaxScRate(false);
 
         Server s1 = network.addServer(service_curve, max_service_curve);
-        s1.setUseGamma(false);
-        s1.setUseExtraGamma(false);
+        s1.useMaxSC(false);
+        s1.useMaxScRate(false);
 
         network.addTurn(s0, s1);
 

--- a/src/main/java/de/uni_kl/cs/discodnc/demos/Demo4.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/demos/Demo4.java
@@ -69,8 +69,8 @@ public class Demo4 {
 
         for (int i = 1; i < numServers; i++) {
             servers[i] = sg.addServer(service_curve, max_service_curve);
-            servers[i].setUseGamma(false);
-            servers[i].setUseExtraGamma(false);
+            servers[i].useMaxSC(false);
+            servers[i].useMaxScRate(false);
         }
 
         sg.addTurn(servers[1], servers[2]);

--- a/src/main/java/de/uni_kl/cs/discodnc/feedforward/arrivalbounds/AggregatePmoo.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/feedforward/arrivalbounds/AggregatePmoo.java
@@ -35,7 +35,7 @@ import java.util.Set;
 
 import de.uni_kl.cs.discodnc.AnalysisConfig;
 import de.uni_kl.cs.discodnc.AnalysisConfig.Multiplexing;
-import de.uni_kl.cs.discodnc.AnalysisConfig.MuxDiscipline;
+import de.uni_kl.cs.discodnc.AnalysisConfig.MultiplexingEnforcement;
 import de.uni_kl.cs.discodnc.bounds.disco.pwaffine.Bound;
 import de.uni_kl.cs.discodnc.curves.ArrivalCurve;
 import de.uni_kl.cs.discodnc.curves.Curve;
@@ -108,9 +108,9 @@ public class AggregatePmoo extends AbstractArrivalBound implements ArrivalBound 
 			return new HashSet<ArrivalCurve>(Collections.singleton(Curve.getFactory().createZeroArrivals()));
 		}
 
-		if (configuration.multiplexingDiscipline() == MuxDiscipline.GLOBAL_FIFO
-				|| (configuration.multiplexingDiscipline() == MuxDiscipline.SERVER_LOCAL
-						&& turn.getSource().multiplexingDiscipline() == Multiplexing.FIFO)) {
+		if (configuration.multiplexingEnforcement() == MultiplexingEnforcement.GLOBAL_FIFO
+				|| (configuration.multiplexingEnforcement() == MultiplexingEnforcement.SERVER_LOCAL
+						&& turn.getSource().multiplexing() == Multiplexing.FIFO)) {
 			throw new Exception("PMOO arrival bounding is not available for FIFO multiplexing nodes");
 		}
 

--- a/src/main/java/de/uni_kl/cs/discodnc/feedforward/arrivalbounds/AggregatePmoo.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/feedforward/arrivalbounds/AggregatePmoo.java
@@ -108,8 +108,8 @@ public class AggregatePmoo extends AbstractArrivalBound implements ArrivalBound 
 			return new HashSet<ArrivalCurve>(Collections.singleton(Curve.getFactory().createZeroArrivals()));
 		}
 
-		if (configuration.multiplexingEnforcement() == MultiplexingEnforcement.GLOBAL_FIFO
-				|| (configuration.multiplexingEnforcement() == MultiplexingEnforcement.SERVER_LOCAL
+		if (configuration.enforceMultiplexing() == MultiplexingEnforcement.GLOBAL_FIFO
+				|| (configuration.enforceMultiplexing() == MultiplexingEnforcement.SERVER_LOCAL
 						&& turn.getSource().multiplexing() == Multiplexing.FIFO)) {
 			throw new Exception("PMOO arrival bounding is not available for FIFO multiplexing nodes");
 		}

--- a/src/main/java/de/uni_kl/cs/discodnc/feedforward/arrivalbounds/AggregateTandemMatching.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/feedforward/arrivalbounds/AggregateTandemMatching.java
@@ -89,8 +89,8 @@ public class AggregateTandemMatching extends AbstractArrivalBound implements Arr
 			return new HashSet<ArrivalCurve>(Collections.singleton(Curve.getFactory().createZeroArrivals()));
 		}
 
-		if (configuration.multiplexingEnforcement() == MultiplexingEnforcement.GLOBAL_FIFO
-				|| (configuration.multiplexingEnforcement() == MultiplexingEnforcement.SERVER_LOCAL
+		if (configuration.enforceMultiplexing() == MultiplexingEnforcement.GLOBAL_FIFO
+				|| (configuration.enforceMultiplexing() == MultiplexingEnforcement.SERVER_LOCAL
 						&& turn.getSource().multiplexing() == Multiplexing.FIFO)) {
 			throw new Exception( "Tandem matching arrival bounding is not available for FIFO multiplexing nodes" );
 		}

--- a/src/main/java/de/uni_kl/cs/discodnc/feedforward/arrivalbounds/AggregateTandemMatching.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/feedforward/arrivalbounds/AggregateTandemMatching.java
@@ -34,7 +34,7 @@ import java.util.Set;
 
 import de.uni_kl.cs.discodnc.Calculator;
 import de.uni_kl.cs.discodnc.AnalysisConfig.Multiplexing;
-import de.uni_kl.cs.discodnc.AnalysisConfig.MuxDiscipline;
+import de.uni_kl.cs.discodnc.AnalysisConfig.MultiplexingEnforcement;
 import de.uni_kl.cs.discodnc.bounds.disco.pwaffine.Bound;
 import de.uni_kl.cs.discodnc.AlgDncBackend_DNC_Affine;
 import de.uni_kl.cs.discodnc.AnalysisConfig;
@@ -89,9 +89,9 @@ public class AggregateTandemMatching extends AbstractArrivalBound implements Arr
 			return new HashSet<ArrivalCurve>(Collections.singleton(Curve.getFactory().createZeroArrivals()));
 		}
 
-		if (configuration.multiplexingDiscipline() == MuxDiscipline.GLOBAL_FIFO
-				|| (configuration.multiplexingDiscipline() == MuxDiscipline.SERVER_LOCAL
-						&& turn.getSource().multiplexingDiscipline() == Multiplexing.FIFO)) {
+		if (configuration.multiplexingEnforcement() == MultiplexingEnforcement.GLOBAL_FIFO
+				|| (configuration.multiplexingEnforcement() == MultiplexingEnforcement.SERVER_LOCAL
+						&& turn.getSource().multiplexing() == Multiplexing.FIFO)) {
 			throw new Exception( "Tandem matching arrival bounding is not available for FIFO multiplexing nodes" );
 		}
 

--- a/src/main/java/de/uni_kl/cs/discodnc/network/server_graph/Path.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/network/server_graph/Path.java
@@ -207,59 +207,10 @@ public class Path {
 
     /**
      * Returns the convolution of the maximum service curves of all servers on the
-     * given lnik path <code>path</code> that have the useGamma flag set.<br>
-     * If a server either has no maximum service curve set or useGamma is disabled,
+     * given lnik path <code>path</code> that have the useMaxSC flag set.<br>
+     * If a server either has no maximum service curve set or useMaxSC is disabled,
      * calculations take place with the default maximum service curve, i.e., the
      * zero delay burst curve, so the result will not be influenced.
-     *
-     * @return The convolved curve
-     * @throws Exception
-     */
-    public MaxServiceCurve getGamma() throws Exception {
-        Collection<Server> servers = getServers();
-        return getGamma(servers);
-    }
-
-    private MaxServiceCurve getGamma(Collection<Server> servers) throws Exception {
-        MaxServiceCurve gamma_total = Curve.getFactory().createZeroDelayInfiniteBurstMSC();
-        for (Server s : servers) {
-            gamma_total = Calculator.getInstance().getMinPlus().convolve(gamma_total, s.getGamma());
-        }
-
-        return gamma_total;
-    }
-
-    /**
-     * Returns the convolution of the maximum service curves of all servers on the
-     * given turn path <code>path</code> that have the useExtraGamma flag set.<br>
-     * If a server either has no maximum service curve set or useExtraGamma is
-     * disabled, calculations take place with the default maximum service curve,
-     * i.e., the zero delay burst curve, so the result will not be influenced.
-     *
-     * @return The convolved curve
-     * @throws Exception
-     */
-    public MaxServiceCurve getExtraGamma() throws Exception {
-        Collection<Server> servers = getServers();
-        return getExtraGamma(servers);
-    }
-
-    private MaxServiceCurve getExtraGamma(Collection<Server> servers) throws Exception {
-        MaxServiceCurve extra_gamma_total = Curve.getFactory().createZeroDelayInfiniteBurstMSC();
-        for (Server s : servers) {
-            extra_gamma_total = Calculator.getInstance().getMinPlus().convolve(extra_gamma_total, s.getExtraGamma());
-        }
-        // extra_gamma_total.removeLatency(); // Already done by s.getExtraGamma()
-
-        return extra_gamma_total;
-    }
-
-    /**
-     * Returns the convolution of the maximum service curves of all servers on the
-     * given turn path <code>path</code><br>
-     * If a server has no maximum service curve, calculations take place with the
-     * default maximum service curve, i.e., the zero delay burst curve, so the
-     * result will not be influenced.
      *
      * @return The convolved curve
      * @throws Exception
@@ -270,14 +221,68 @@ public class Path {
     }
 
     private MaxServiceCurve getMaxServiceCurve(Collection<Server> servers) throws Exception {
-        MaxServiceCurve max_service_curve_total = Curve.getFactory().createZeroDelayInfiniteBurstMSC();
+        MaxServiceCurve max_sc_path = Curve.getFactory().createZeroDelayInfiniteBurstMSC();
         for (Server s : servers) {
-            max_service_curve_total = Calculator.getInstance().getMinPlus().convolve(max_service_curve_total, s.getMaxServiceCurve());
+            max_sc_path = Calculator.getInstance().getMinPlus().convolve(max_sc_path, s.getMaxServiceCurve());
         }
 
-        return max_service_curve_total;
+        return max_sc_path;
     }
 
+    public MaxServiceCurve getStoredMaxSC() throws Exception {
+        Collection<Server> servers = getServers();
+        return getStoredMaxSC(servers);
+    }
+
+    private MaxServiceCurve getStoredMaxSC(Collection<Server> servers) throws Exception {
+        MaxServiceCurve max_sc_path = Curve.getFactory().createZeroDelayInfiniteBurstMSC();
+        for (Server s : servers) {
+            max_sc_path = Calculator.getInstance().getMinPlus().convolve(max_sc_path, s.getStoredMaxSC());
+        }
+
+        return max_sc_path;
+    }
+
+    /**
+     * Returns the convolution of the maximum service curves of all servers on the
+     * given turn path <code>path</code> that have the useMaxScRate flag set.<br>
+     * If a server either has no maximum service curve set or useMaxScRate is
+     * disabled, calculations take place with the default maximum service curve,
+     * i.e., the zero delay burst curve, so the result will not be influenced.
+     *
+     * @return The convolved curve
+     * @throws Exception
+     */
+    public MaxServiceCurve getMaxScRate() throws Exception {
+        Collection<Server> servers = getServers();
+        return getMaxScRate(servers);
+    }
+
+    private MaxServiceCurve getMaxScRate(Collection<Server> servers) throws Exception {
+        MaxServiceCurve max_sc_rate_path = Curve.getFactory().createZeroDelayInfiniteBurstMSC();
+        for (Server s : servers) {
+            max_sc_rate_path = Calculator.getInstance().getMinPlus().convolve(max_sc_rate_path, s.getMaxScRate());
+        }
+        // max_sc_rate_path.removeLatency(); // Already done by s.getMaxScRate()
+
+        return max_sc_rate_path;
+    }
+    
+    public MaxServiceCurve getStoredMaxScRate() throws Exception {
+        Collection<Server> servers = getServers();
+        return getStoredMaxScRate(servers);
+    }
+
+    private MaxServiceCurve getStoredMaxScRate(Collection<Server> servers) throws Exception {
+        MaxServiceCurve max_sc_rate_path = Curve.getFactory().createZeroDelayInfiniteBurstMSC();
+        for (Server s : servers) {
+            max_sc_rate_path = Calculator.getInstance().getMinPlus().convolve(max_sc_rate_path, s.getStoredMaxScRate());
+        }
+        // max_sc_rate_path.removeLatency(); // Already done by s.getStoredMaxScRate()
+
+        return max_sc_rate_path;
+    }
+    
     @Override
     public boolean equals(Object obj) {
         if (obj == null || !(obj instanceof Path)) {

--- a/src/main/java/de/uni_kl/cs/discodnc/network/server_graph/Server.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/network/server_graph/Server.java
@@ -69,7 +69,7 @@ public class Server {
      * @param alias             The server's alias (not necessarily unique).
      * @param service_curve     The server's service curve.
      * @param max_service_curve The server's maximum service curve.
-     * @param multiplexing      The server's flow multiplexing discipline.
+     * @param multiplexing      The server's flow multiplexing setting.
      * @param use_gamma         Convolve the maximum service curve with the arrival curve before
      *                          deriving an output bound.
      * @param use_extra_gamma   Convolve the output bound with the maximum service curve.
@@ -191,12 +191,12 @@ public class Server {
         this.use_extra_gamma = use_extra_gamma;
     }
 
-    public Multiplexing multiplexingDiscipline() {
+    public Multiplexing multiplexing() {
         return multiplexing;
     }
 
-    public void setMultiplexingDiscipline(Multiplexing mux) {
-        multiplexing = mux;
+    public void setMultiplexing(Multiplexing multiplexing) {
+        this.multiplexing = multiplexing;
     }
 
     public String getAlias() {

--- a/src/main/java/de/uni_kl/cs/discodnc/network/server_graph/Server.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/network/server_graph/Server.java
@@ -49,14 +49,14 @@ public class Server {
     /**
      * Whether to use maximum service curves in output bound computation
      */
-    private boolean use_gamma = false;
+    private boolean use_max_sc = false;
 
     /**
      * Whether to constrain the output bound further through convolution with the
      * maximum service curve's rate as the server cannot output data faster than
      * this rate.
      */
-    private boolean use_extra_gamma = false;
+    private boolean use_max_sc_output_rate = false;
 
     private Multiplexing multiplexing = Multiplexing.ARBITRARY;
 
@@ -65,25 +65,25 @@ public class Server {
     }
 
     /**
-     * @param id                The server's id (unique).
-     * @param alias             The server's alias (not necessarily unique).
-     * @param service_curve     The server's service curve.
-     * @param max_service_curve The server's maximum service curve.
-     * @param multiplexing      The server's flow multiplexing setting.
-     * @param use_gamma         Convolve the maximum service curve with the arrival curve before
-     *                          deriving an output bound.
-     * @param use_extra_gamma   Convolve the output bound with the maximum service curve.
+     * @param id						The server's id (unique).
+     * @param alias						The server's alias (not necessarily unique).
+     * @param service_curve				The server's service curve.
+     * @param max_service_curve			The server's maximum service curve.
+     * @param multiplexing				The server's flow multiplexing setting.
+     * @param use_max_sc				Convolve the maximum service curve with the arrival curve before
+     *                          		deriving an output bound.
+     * @param use_max_sc_output_rate	Convolve the output bound with the maximum service curve.
      */
     protected Server(int id, String alias, ServiceCurve service_curve, MaxServiceCurve max_service_curve,
-                     Multiplexing multiplexing, boolean use_gamma, boolean use_extra_gamma) {
+                     Multiplexing multiplexing, boolean use_max_sc, boolean use_max_sc_output_rate) {
         this.id = id;
         this.alias = alias;
         this.service_curve = service_curve;
         this.max_service_curve = max_service_curve;
         max_service_curve_flag = true;
         this.multiplexing = multiplexing;
-        this.use_gamma = use_gamma;
-        this.use_extra_gamma = use_extra_gamma;
+        this.use_max_sc = use_max_sc;
+        this.use_max_sc_output_rate = use_max_sc_output_rate;
     }
 
     protected Server(int id, String alias, ServiceCurve service_curve, Multiplexing multiplexing) {
@@ -110,7 +110,7 @@ public class Server {
     }
 
     /**
-     * Setting a maximum service curve also enables useGamma and useExtraGamma.
+     * Setting a maximum service curve also enables useMaxSC and useMaxScRate.
      *
      * @param max_service_curve The maximum service curve.
      * @return Signals success of the operation.
@@ -119,12 +119,12 @@ public class Server {
         return setMaxServiceCurve(max_service_curve, true, true);
     }
 
-    public boolean setMaxServiceCurve(MaxServiceCurve max_service_curve, boolean use_gamma, boolean use_extra_gamma) {
+    public boolean setMaxServiceCurve(MaxServiceCurve max_service_curve, boolean use_max_sc, boolean use_max_sc_output_rate) {
         this.max_service_curve = max_service_curve;
 
         max_service_curve_flag = true;
-        this.use_gamma = true;
-        this.use_extra_gamma = true;
+        this.use_max_sc = use_max_sc;
+        this.use_max_sc_output_rate = use_max_sc_output_rate;
 
         return true;
     }
@@ -133,28 +133,19 @@ public class Server {
         max_service_curve = Curve.getFactory().createZeroDelayInfiniteBurstMSC();
 
         max_service_curve_flag = false;
-        use_gamma = false;
-        use_extra_gamma = false;
+        use_max_sc = false;
+        use_max_sc_output_rate = false;
 
         return true;
     }
 
     /**
+     * This function always returns the default zero delay burst curve if the useMaxSC flag is not set.
+     * 
      * @return A copy of the maximum service curve
      */
     public MaxServiceCurve getMaxServiceCurve() {
-        return max_service_curve; // No need to check max_service_curve_set as it will always be at least a zero
-        // delay infinite burst curve
-    }
-
-    /**
-     * In contrast to <code>getMaxServiceCurve()</code> this function always returns
-     * the default zero delay burst curve if the useGamma flag is not set.
-     *
-     * @return The gamma curve
-     */
-    public MaxServiceCurve getGamma() {
-        if (use_gamma == false) {
+        if (use_max_sc == false) {
             return Curve.getFactory().createZeroDelayInfiniteBurstMSC();
         } else {
             return max_service_curve;
@@ -162,33 +153,47 @@ public class Server {
     }
 
     /**
-     * In contrast to <code>getMaxServiceCurve()</code> this function always returns
-     * the default zero delay burst curve if the useExtraGamma flag is not set.
-     *
-     * @return The gamma curve
+     * @return The stored maximum service curve
      */
-    public MaxServiceCurve getExtraGamma() {
-        if (use_extra_gamma == false) {
+    public MaxServiceCurve getStoredMaxSC() {
+    	return max_service_curve;
+    }
+
+    /**
+     * In contrast to <code>getMaxServiceCurve()</code> this function always returns
+     * the default zero delay burst curve if the useMaxScRate flag is not set.
+     *
+     * @return The maximum service curve
+     */
+    public MaxServiceCurve getMaxScRate() {
+        if (use_max_sc_output_rate == false) {
             return Curve.getFactory().createZeroDelayInfiniteBurstMSC();
         } else {
             return (MaxServiceCurve) Curve.removeLatency(max_service_curve);
         }
     }
 
-    public boolean useGamma() {
-        return use_gamma;
+    /**
+     * @return The stored maximum service curve rate
+     */
+    public MaxServiceCurve getStoredMaxScRate() {
+    	return (MaxServiceCurve) Curve.removeLatency(max_service_curve);
     }
 
-    public void setUseGamma(boolean use_gamma) {
-        this.use_gamma = use_gamma;
+    public boolean useMaxSC() {
+        return use_max_sc;
     }
 
-    public boolean useExtraGamma() {
-        return use_extra_gamma;
+    public void useMaxSC(boolean use_max_sc) {
+        this.use_max_sc = use_max_sc;
     }
 
-    public void setUseExtraGamma(boolean use_extra_gamma) {
-        this.use_extra_gamma = use_extra_gamma;
+    public boolean useMaxScRate() {
+        return use_max_sc_output_rate;
+    }
+
+    public void useMaxScRate(boolean use_max_sc_output_rate) {
+        this.use_max_sc_output_rate = use_max_sc_output_rate;
     }
 
     public Multiplexing multiplexing() {
@@ -246,9 +251,9 @@ public class Server {
     	
     	server_msc_str.append(max_service_curve.toString());
     	server_msc_str.append(", ");
-    	server_msc_str.append(Boolean.toString(use_gamma));
+    	server_msc_str.append(Boolean.toString(use_max_sc));
     	server_msc_str.append(", ");
-    	server_msc_str.append(Boolean.toString(use_extra_gamma));
+    	server_msc_str.append(Boolean.toString(use_max_sc_output_rate));
     	
     	return server_msc_str;
     }

--- a/src/main/java/de/uni_kl/cs/discodnc/network/server_graph/ServerGraph.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/network/server_graph/ServerGraph.java
@@ -1336,7 +1336,7 @@ public class ServerGraph {
 
 		for (Server s_old : servers) {
 			s_new = sg_new.addServer(s_old.getAlias(), s_old.getServiceCurve().copy(),
-					s_old.getMaxServiceCurve().copy(), s_old.multiplexingDiscipline(), s_old.useGamma(),
+					s_old.getMaxServiceCurve().copy(), s_old.multiplexing(), s_old.useGamma(),
 					s_old.useExtraGamma());
 			map__s_old__s_new.put(s_old, s_new);
 		}
@@ -1454,7 +1454,7 @@ public class ServerGraph {
 					+ ", ");
 			sb.append("CurvePwAffine.getFactory().createMaxServiceCurve( \"" + s.getMaxServiceCurve().toString()
 					+ "\" )" + ", ");
-			sb.append("Multiplexing." + s.multiplexingDiscipline() + ", ");
+			sb.append("Multiplexing." + s.multiplexing() + ", ");
 			sb.append(s.useGamma() + ", ");
 			sb.append(s.useExtraGamma());
 			sb.append(" );\n");

--- a/src/main/java/de/uni_kl/cs/discodnc/network/server_graph/ServerGraph.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/network/server_graph/ServerGraph.java
@@ -191,7 +191,7 @@ public class ServerGraph {
 	// With given maximum service curve
 
 	/**
-	 * By default the server's use_gamma and use_extra_gamma are enabled
+	 * By default the server's use_max_sc and use_max_sc_output_rate are enabled
 	 *
 	 * @param service_curve
 	 *            The server's service curve.
@@ -204,7 +204,7 @@ public class ServerGraph {
 	}
 
 	/**
-	 * By default the server's use_gamma and use_extra_gamma are enabled
+	 * By default the server's use_max_sc and use_max_sc_output_rate are enabled
 	 *
 	 * @param alias
 	 *            The server's user-defined alias.
@@ -218,38 +218,32 @@ public class ServerGraph {
 		return addServer(alias, service_curve, max_service_curve, Multiplexing.ARBITRARY, true, true);
 	}
 
-	public Server addServer(ServiceCurve service_curve, MaxServiceCurve max_service_curve, boolean use_gamma,
-			boolean use_extra_gamma) {
-		return addServer(service_curve, max_service_curve, Multiplexing.ARBITRARY, use_gamma,
-				use_extra_gamma);
+	public Server addServer(ServiceCurve service_curve, MaxServiceCurve max_service_curve, boolean use_max_sc, boolean use_max_sc_output_rate) {
+		return addServer(service_curve, max_service_curve, Multiplexing.ARBITRARY, use_max_sc, use_max_sc_output_rate);
 	}
 
-	public Server addServer(String alias, ServiceCurve service_curve, MaxServiceCurve max_service_curve,
-			Multiplexing multiplexing) {
+	public Server addServer(String alias, ServiceCurve service_curve, MaxServiceCurve max_service_curve, Multiplexing multiplexing) {
 		return addServer(alias, service_curve, max_service_curve, multiplexing, true, true);
 	}
 
-	public Server addServer(ServiceCurve service_curve, MaxServiceCurve max_service_curve,
-			Multiplexing multiplexing) {
+	public Server addServer(ServiceCurve service_curve, MaxServiceCurve max_service_curve, Multiplexing multiplexing) {
 		return addServer(service_curve, max_service_curve, multiplexing, true, true);
 	}
 
-	public Server addServer(String alias, ServiceCurve service_curve, MaxServiceCurve max_service_curve,
-			boolean use_gamma, boolean use_extra_gamma) {
-		return addServer(alias, service_curve, max_service_curve, Multiplexing.ARBITRARY, use_gamma,
-				use_extra_gamma);
+	public Server addServer(String alias, ServiceCurve service_curve, MaxServiceCurve max_service_curve, boolean use_max_sc, boolean use_max_sc_output_rate) {
+		return addServer(alias, service_curve, max_service_curve, Multiplexing.ARBITRARY, use_max_sc, use_max_sc_output_rate);
 	}
 
 	public Server addServer(ServiceCurve service_curve, MaxServiceCurve max_service_curve,
-			Multiplexing multiplexing, boolean use_gamma, boolean use_extra_gamma) {
+							Multiplexing multiplexing, boolean use_max_sc, boolean use_max_sc_output_rate) {
 		String alias = server_default_name_prefix + Integer.toString(server_id_counter);
-		return addServer(alias, service_curve, max_service_curve, multiplexing, use_gamma, use_extra_gamma);
+		return addServer(alias, service_curve, max_service_curve, multiplexing, use_max_sc, use_max_sc_output_rate);
 	}
 
 	public Server addServer(String alias, ServiceCurve service_curve, MaxServiceCurve max_service_curve,
-			Multiplexing multiplexing, boolean use_gamma, boolean use_extra_gamma) {
+							Multiplexing multiplexing, boolean use_max_sc, boolean use_max_sc_output_rate) {
 		Server new_server = new Server(server_id_counter, alias, service_curve.copy(), max_service_curve.copy(),
-				multiplexing, use_gamma, use_extra_gamma);
+										multiplexing, use_max_sc, use_max_sc_output_rate);
 		updateServerAdditionInternally(new_server);
 
 		return new_server;
@@ -1336,8 +1330,8 @@ public class ServerGraph {
 
 		for (Server s_old : servers) {
 			s_new = sg_new.addServer(s_old.getAlias(), s_old.getServiceCurve().copy(),
-					s_old.getMaxServiceCurve().copy(), s_old.multiplexing(), s_old.useGamma(),
-					s_old.useExtraGamma());
+					s_old.getMaxServiceCurve().copy(), s_old.multiplexing(), s_old.useMaxSC(),
+					s_old.useMaxScRate());
 			map__s_old__s_new.put(s_old, s_new);
 		}
 
@@ -1455,8 +1449,8 @@ public class ServerGraph {
 			sb.append("CurvePwAffine.getFactory().createMaxServiceCurve( \"" + s.getMaxServiceCurve().toString()
 					+ "\" )" + ", ");
 			sb.append("Multiplexing." + s.multiplexing() + ", ");
-			sb.append(s.useGamma() + ", ");
-			sb.append(s.useExtraGamma());
+			sb.append(s.useMaxSC() + ", ");
+			sb.append(s.useMaxScRate());
 			sb.append(" );\n");
 
 			i_servers_lines++;

--- a/src/main/java/de/uni_kl/cs/discodnc/tandem/analyses/PmooAnalysis.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/tandem/analyses/PmooAnalysis.java
@@ -285,7 +285,7 @@ public class PmooAnalysis extends AbstractAnalysis implements Analysis {
     }
 
     public void performAnalysis(Flow flow_of_interest, Path path) throws Exception {
-        if (configuration.multiplexingEnforcement() == MultiplexingEnforcement.GLOBAL_FIFO) {
+        if (configuration.enforceMultiplexing() == MultiplexingEnforcement.GLOBAL_FIFO) {
             throw new Exception("PMOO analysis is not available for FIFO multiplexing nodes");
         }
 
@@ -314,7 +314,7 @@ public class PmooAnalysis extends AbstractAnalysis implements Analysis {
 
     public Set<ServiceCurve> getServiceCurves(Flow flow_of_interest, Path path, Set<Flow> flows_to_serve)
             throws Exception {
-        if (configuration.multiplexingEnforcement() == MultiplexingEnforcement.SERVER_LOCAL) {
+        if (configuration.enforceMultiplexing() == MultiplexingEnforcement.SERVER_LOCAL) {
             for (Server s : path.getServers()) {
                 if (s.multiplexing() == Multiplexing.FIFO) {
                     throw new Exception("PMOO analysis is not available for FIFO multiplexing nodes");

--- a/src/main/java/de/uni_kl/cs/discodnc/tandem/analyses/PmooAnalysis.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/tandem/analyses/PmooAnalysis.java
@@ -42,7 +42,7 @@ import java.util.Set;
 import de.uni_kl.cs.discodnc.AnalysisConfig;
 import de.uni_kl.cs.discodnc.Calculator;
 import de.uni_kl.cs.discodnc.AnalysisConfig.Multiplexing;
-import de.uni_kl.cs.discodnc.AnalysisConfig.MuxDiscipline;
+import de.uni_kl.cs.discodnc.AnalysisConfig.MultiplexingEnforcement;
 import de.uni_kl.cs.discodnc.bounds.disco.pwaffine.Bound;
 import de.uni_kl.cs.discodnc.curves.ArrivalCurve;
 import de.uni_kl.cs.discodnc.curves.Curve;
@@ -285,7 +285,7 @@ public class PmooAnalysis extends AbstractAnalysis implements Analysis {
     }
 
     public void performAnalysis(Flow flow_of_interest, Path path) throws Exception {
-        if (configuration.multiplexingDiscipline() == MuxDiscipline.GLOBAL_FIFO) {
+        if (configuration.multiplexingEnforcement() == MultiplexingEnforcement.GLOBAL_FIFO) {
             throw new Exception("PMOO analysis is not available for FIFO multiplexing nodes");
         }
 
@@ -314,9 +314,9 @@ public class PmooAnalysis extends AbstractAnalysis implements Analysis {
 
     public Set<ServiceCurve> getServiceCurves(Flow flow_of_interest, Path path, Set<Flow> flows_to_serve)
             throws Exception {
-        if (configuration.multiplexingDiscipline() == MuxDiscipline.SERVER_LOCAL) {
+        if (configuration.multiplexingEnforcement() == MultiplexingEnforcement.SERVER_LOCAL) {
             for (Server s : path.getServers()) {
-                if (s.multiplexingDiscipline() == Multiplexing.FIFO) {
+                if (s.multiplexing() == Multiplexing.FIFO) {
                     throw new Exception("PMOO analysis is not available for FIFO multiplexing nodes");
                 }
             }

--- a/src/main/java/de/uni_kl/cs/discodnc/tandem/analyses/TandemMatchingAnalysis.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/tandem/analyses/TandemMatchingAnalysis.java
@@ -89,11 +89,11 @@ public class TandemMatchingAnalysis extends AbstractAnalysis implements Analysis
 
 	public void performAnalysis( Flow flow_of_interest, Path path ) throws Exception
 	{
-		if( configuration.multiplexingEnforcement() == MultiplexingEnforcement.GLOBAL_FIFO )
+		if( configuration.enforceMultiplexing() == MultiplexingEnforcement.GLOBAL_FIFO )
 		{
 			throw new Exception( "Cutting analysis is not available for FIFO multiplexing nodes" );
 		} else {
-			if( configuration.multiplexingEnforcement() == MultiplexingEnforcement.SERVER_LOCAL ) {
+			if( configuration.enforceMultiplexing() == MultiplexingEnforcement.SERVER_LOCAL ) {
 				for( Server s : path.getServers() ) {
 					if( s.multiplexing() == Multiplexing.FIFO ) {
 						throw new Exception( "Cutting analysis is not available for FIFO multiplexing nodes" );

--- a/src/main/java/de/uni_kl/cs/discodnc/tandem/analyses/TandemMatchingAnalysis.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/tandem/analyses/TandemMatchingAnalysis.java
@@ -39,7 +39,7 @@ import java.util.Map.Entry;
 import de.uni_kl.cs.discodnc.AnalysisConfig;
 import de.uni_kl.cs.discodnc.Calculator;
 import de.uni_kl.cs.discodnc.AnalysisConfig.Multiplexing;
-import de.uni_kl.cs.discodnc.AnalysisConfig.MuxDiscipline;
+import de.uni_kl.cs.discodnc.AnalysisConfig.MultiplexingEnforcement;
 import de.uni_kl.cs.discodnc.bounds.disco.pwaffine.Bound;
 import de.uni_kl.cs.discodnc.numbers.Num;
 import de.uni_kl.cs.discodnc.tandem.AbstractAnalysis;
@@ -89,13 +89,13 @@ public class TandemMatchingAnalysis extends AbstractAnalysis implements Analysis
 
 	public void performAnalysis( Flow flow_of_interest, Path path ) throws Exception
 	{
-		if( configuration.multiplexingDiscipline() == MuxDiscipline.GLOBAL_FIFO )
+		if( configuration.multiplexingEnforcement() == MultiplexingEnforcement.GLOBAL_FIFO )
 		{
 			throw new Exception( "Cutting analysis is not available for FIFO multiplexing nodes" );
 		} else {
-			if( configuration.multiplexingDiscipline() == MuxDiscipline.SERVER_LOCAL ) {
+			if( configuration.multiplexingEnforcement() == MultiplexingEnforcement.SERVER_LOCAL ) {
 				for( Server s : path.getServers() ) {
-					if( s.multiplexingDiscipline() == Multiplexing.FIFO ) {
+					if( s.multiplexing() == Multiplexing.FIFO ) {
 						throw new Exception( "Cutting analysis is not available for FIFO multiplexing nodes" );
 					}
 				}

--- a/src/main/java/de/uni_kl/cs/discodnc/tandem/analyses/TotalFlowAnalysis.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/tandem/analyses/TotalFlowAnalysis.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import de.uni_kl.cs.discodnc.AnalysisConfig;
 import de.uni_kl.cs.discodnc.Calculator;
 import de.uni_kl.cs.discodnc.AnalysisConfig.Multiplexing;
-import de.uni_kl.cs.discodnc.AnalysisConfig.MuxDiscipline;
+import de.uni_kl.cs.discodnc.AnalysisConfig.MultiplexingEnforcement;
 import de.uni_kl.cs.discodnc.bounds.disco.pwaffine.Bound;
 import de.uni_kl.cs.discodnc.curves.ArrivalCurve;
 import de.uni_kl.cs.discodnc.curves.ServiceCurve;
@@ -122,9 +122,9 @@ public class TotalFlowAnalysis extends AbstractAnalysis implements Analysis {
             }
 
             Num delay_bound_server_alpha;
-            if (configuration.multiplexingDiscipline() == MuxDiscipline.GLOBAL_FIFO
-                    || (configuration.multiplexingDiscipline() == MuxDiscipline.SERVER_LOCAL
-                    && server.multiplexingDiscipline() == Multiplexing.FIFO)
+            if (configuration.multiplexingEnforcement() == MultiplexingEnforcement.GLOBAL_FIFO
+                    || (configuration.multiplexingEnforcement() == MultiplexingEnforcement.SERVER_LOCAL
+                    && server.multiplexing() == Multiplexing.FIFO)
                     || fifo_per_micro_flow) {
                 delay_bound_server_alpha = Bound.delayFIFO(alpha_candidate, beta_server);
             } else {

--- a/src/main/java/de/uni_kl/cs/discodnc/tandem/analyses/TotalFlowAnalysis.java
+++ b/src/main/java/de/uni_kl/cs/discodnc/tandem/analyses/TotalFlowAnalysis.java
@@ -122,8 +122,8 @@ public class TotalFlowAnalysis extends AbstractAnalysis implements Analysis {
             }
 
             Num delay_bound_server_alpha;
-            if (configuration.multiplexingEnforcement() == MultiplexingEnforcement.GLOBAL_FIFO
-                    || (configuration.multiplexingEnforcement() == MultiplexingEnforcement.SERVER_LOCAL
+            if (configuration.enforceMultiplexing() == MultiplexingEnforcement.GLOBAL_FIFO
+                    || (configuration.enforceMultiplexing() == MultiplexingEnforcement.SERVER_LOCAL
                     && server.multiplexing() == Multiplexing.FIFO)
                     || fifo_per_micro_flow) {
                 delay_bound_server_alpha = Bound.delayFIFO(alpha_candidate, beta_server);


### PR DESCRIPTION
For Multiplexing, renaming was sufficient to differentiate between the Multiplexing assumed by servers and the global enforcement of some setting.

For the maximum service curve, there was renaming (do not call it gamma anymore) as well as bugfixes so the actually configured enforcement of a certain global setting is correctly executed.